### PR TITLE
feat: integrate points type handling across game components and utilities

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,10 +1,11 @@
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 
+import { Stack } from "expo-router";
+
 import { ThemeContextProvider } from "@belot/components";
 import { LocalizationContextProvider } from "@belot/localizations";
 
 import { FeatureToggleProvider } from "@/components/featureToggles/FeatureToggleProvider";
-import Navigation from "@/components/navigation";
 import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
 
 import { getDeviceLanguage } from "@/helpers/localization";
@@ -26,7 +27,12 @@ export default function RootLayout() {
             <ThemeContextProvider initialTheme={theme}>
               <GluestackUIProvider mode="system">
                 <SafeAreaView className="relative w-full flex-1 bg-phone-screen-background">
-                  <Navigation />
+                  <Stack
+                    screenOptions={{
+                      headerShown: false,
+                      contentStyle: { backgroundColor: "transparent" },
+                    }}
+                  />
                 </SafeAreaView>
               </GluestackUIProvider>
             </ThemeContextProvider>

--- a/apps/mobile/app/game-table.tsx
+++ b/apps/mobile/app/game-table.tsx
@@ -6,10 +6,10 @@ import GameTable from "@/components/game-table";
 import Header from "@/components/game-table/header";
 import { Divider } from "@/components/ui/divider";
 
-import { getFromStorage } from "@/helpers/storageHelpers";
+import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
 
 export default function GameTableScreen() {
-  useLoadGameData({ getFromStorage });
+  useLoadGameData({ getFromStorage, setToStorage });
 
   return (
     <View className="flex-1 content-center">

--- a/apps/mobile/app/settings-screen.tsx
+++ b/apps/mobile/app/settings-screen.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { useFocusEffect } from "expo-router";
 
-import { useSettings } from "@belot/hooks";
+import { useSettings, useIsPointsTypeEnabled } from "@belot/hooks";
 import { useLocalization } from "@belot/localizations";
 
 import { BackButton } from "@/components/backButton";
@@ -14,6 +14,7 @@ import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
 
 export default function SettingsScreen() {
   const settingsMsg = useLocalization("settings");
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
 
   const { settings, setSettings, getSettingsFromLocalStorage } = useSettings({
     getFromStorage,
@@ -31,7 +32,9 @@ export default function SettingsScreen() {
       <BackButton />
       <PageHeader title={settingsMsg} />
       <VStack className="flex-1 items-center justify-center gap-4">
-        <PointsTypeRadioButton value={settings.pointsType} onChange={setSettings} />
+        {isPointsTypeEnabled ? (
+          <PointsTypeRadioButton value={settings.pointsType} onChange={setSettings} />
+        ) : null}
       </VStack>
     </VStack>
   );

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -1,7 +1,5 @@
-import { useCallback } from "react";
-
 import { POINTS_TYPE } from "@belot/constants";
-import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+import { usePointsTypeSelection } from "@belot/hooks";
 
 import { CircleIcon } from "@/components/ui/icon";
 import { Radio, RadioGroup, RadioIcon, RadioIndicator, RadioLabel } from "@/components/ui/radio";
@@ -12,25 +10,7 @@ interface DialogPointsTypeToggleProps {
 }
 
 export default function DialogPointsTypeToggle({ value, onChange }: DialogPointsTypeToggleProps) {
-  const messages = useLocalizations([
-    {
-      key: "settings.points.type.micropoints",
-    },
-    {
-      key: "settings.points.type.points",
-    },
-  ]);
-
-  const handleChange = useCallback(
-    (newValue: string) => {
-      if (newValue === value) {
-        return;
-      }
-
-      onChange(newValue);
-    },
-    [onChange, value],
-  );
+  const { handleChange, getOptionLabel } = usePointsTypeSelection({ value, onChange });
 
   return (
     <RadioGroup value={value} className="flex flex-row items-center justify-center gap-4">
@@ -39,7 +19,7 @@ export default function DialogPointsTypeToggle({ value, onChange }: DialogPoints
           <RadioIndicator>
             <RadioIcon as={CircleIcon} />
           </RadioIndicator>
-          <RadioLabel>{messages[formatLocalizationKey(type.localizationKey)]}</RadioLabel>
+          <RadioLabel>{getOptionLabel(type.localizationKey)}</RadioLabel>
         </Radio>
       ))}
     </RadioGroup>

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { POINTS_TYPE } from "@belot/constants";
 import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
 
-import { CircleIcon, Icon } from "@/components/ui/icon";
+import { CircleIcon } from "@/components/ui/icon";
 import { Radio, RadioGroup, RadioIcon, RadioIndicator, RadioLabel } from "@/components/ui/radio";
 
 interface DialogPointsTypeToggleProps {
@@ -23,9 +23,13 @@ export default function DialogPointsTypeToggle({ value, onChange }: DialogPoints
 
   const handleChange = useCallback(
     (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+
       onChange(newValue);
     },
-    [onChange],
+    [onChange, value],
   );
 
   return (

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+
+import { POINTS_TYPE } from "@belot/constants";
+import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+
+import { CircleIcon, Icon } from "@/components/ui/icon";
+import { Radio, RadioGroup, RadioIcon, RadioIndicator, RadioLabel } from "@/components/ui/radio";
+
+interface DialogPointsTypeToggleProps {
+  value: string;
+  onChange: (pointsType: string) => void;
+}
+
+export default function DialogPointsTypeToggle({ value, onChange }: DialogPointsTypeToggleProps) {
+  const messages = useLocalizations([
+    {
+      key: "settings.points.type.micropoints",
+    },
+    {
+      key: "settings.points.type.points",
+    },
+  ]);
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      onChange(newValue);
+    },
+    [onChange],
+  );
+
+  return (
+    <RadioGroup value={value} className="flex flex-row items-center justify-center gap-4">
+      {POINTS_TYPE.map((type) => (
+        <Radio key={type.id} value={type.id} onPress={() => handleChange(type.id)}>
+          <RadioIndicator>
+            <RadioIcon as={CircleIcon} />
+          </RadioIndicator>
+          <RadioLabel>{messages[formatLocalizationKey(type.localizationKey)]}</RadioLabel>
+        </Radio>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,5 +1,6 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
+import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 
+import { useSyncPlayerScoreInput } from "@belot/hooks";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import { GameMode, Player, PlayerScore, RoundScore, Team, TeamScore } from "@belot/types";
 import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode, getScoreInputMaxLength } from "@belot/utils/src";
@@ -61,36 +62,12 @@ export default function PlayerScoreInput({
     [gameMode, opponent, roundPlayer, setRoundScore],
   );
 
-  const lastSyncedScoreRef = useRef<{
-    opponentId: number;
-    totalRoundScore: number;
-    score: number;
-  } | null>(null);
-
-  useEffect(() => {
-    if (!roundScore.totalRoundScore) {
-      lastSyncedScoreRef.current = null;
-      return;
-    }
-
-    const targetScore = finalRoundScore?.score ?? 0;
-    const lastSyncedScore = lastSyncedScoreRef.current;
-
-    if (
-      lastSyncedScore?.opponentId === opponent.id &&
-      lastSyncedScore.totalRoundScore === roundScore.totalRoundScore &&
-      lastSyncedScore.score === targetScore
-    ) {
-      return;
-    }
-
-    handleInputChange(targetScore);
-    lastSyncedScoreRef.current = {
-      opponentId: opponent.id,
-      totalRoundScore: roundScore.totalRoundScore,
-      score: targetScore,
-    };
-  }, [finalRoundScore?.score, handleInputChange, opponent.id, roundScore.totalRoundScore]);
+  useSyncPlayerScoreInput({
+    opponentId: opponent.id,
+    totalRoundScore: roundScore.totalRoundScore,
+    targetScore: finalRoundScore?.score ?? 0,
+    onScoreChange: handleInputChange,
+  });
 
   return (
     <VStack space="xs">

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,8 +1,9 @@
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo } from "react";
 
+import { useGameStore } from "@belot/store";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import { GameMode, Player, PlayerScore, RoundScore, Team, TeamScore } from "@belot/types";
-import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode } from "@belot/utils/src";
+import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode, getScoreInputMaxLength } from "@belot/utils/src";
 
 import { Input, InputField } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
@@ -27,6 +28,7 @@ export default function PlayerScoreInput({
   teams,
   roundPlayer,
 }: PlayerScoreInputProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const messages = useLocalizations([{ key: "next.round.score.for.player" }]);
 
   const finalRoundScore = useMemo(
@@ -71,7 +73,7 @@ export default function PlayerScoreInput({
       <Input variant="rounded" className="w-full">
         <InputField
           value={String(finalRoundScore?.score || 0)}
-          maxLength={3}
+          maxLength={getScoreInputMaxLength(pointsType)}
           keyboardType="number-pad"
           onChangeText={(value) => handleInputChange(Number(value))}
           selectTextOnFocus

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,6 +1,5 @@
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo } from "react";
 
-import { useGameStore } from "@belot/store";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import { GameMode, Player, PlayerScore, RoundScore, Team, TeamScore } from "@belot/types";
 import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode, getScoreInputMaxLength } from "@belot/utils/src";
@@ -17,6 +16,7 @@ interface PlayerScoreInputProps {
   players: Player[];
   teams: Team[];
   roundPlayer: Player | null;
+  pointsType: string;
 }
 
 export default function PlayerScoreInput({
@@ -27,8 +27,8 @@ export default function PlayerScoreInput({
   players,
   teams,
   roundPlayer,
+  pointsType,
 }: PlayerScoreInputProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
   const messages = useLocalizations([{ key: "next.round.score.for.player" }]);
 
   const finalRoundScore = useMemo(

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useMemo } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import { GameMode, Player, PlayerScore, RoundScore, Team, TeamScore } from "@belot/types";
@@ -61,11 +61,36 @@ export default function PlayerScoreInput({
     [gameMode, opponent, roundPlayer, setRoundScore],
   );
 
+  const lastSyncedScoreRef = useRef<{
+    opponentId: number;
+    totalRoundScore: number;
+    score: number;
+  } | null>(null);
+
   useEffect(() => {
-    if (roundScore.totalRoundScore) {
-      handleInputChange(finalRoundScore?.score || 0);
+    if (!roundScore.totalRoundScore) {
+      lastSyncedScoreRef.current = null;
+      return;
     }
-  }, [finalRoundScore?.score, handleInputChange, roundScore.totalRoundScore]);
+
+    const targetScore = finalRoundScore?.score ?? 0;
+    const lastSyncedScore = lastSyncedScoreRef.current;
+
+    if (
+      lastSyncedScore?.opponentId === opponent.id &&
+      lastSyncedScore.totalRoundScore === roundScore.totalRoundScore &&
+      lastSyncedScore.score === targetScore
+    ) {
+      return;
+    }
+
+    handleInputChange(targetScore);
+    lastSyncedScoreRef.current = {
+      opponentId: opponent.id,
+      totalRoundScore: roundScore.totalRoundScore,
+      score: targetScore,
+    };
+  }, [finalRoundScore?.score, handleInputChange, opponent.id, roundScore.totalRoundScore]);
 
   return (
     <VStack space="xs">

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
@@ -21,18 +21,14 @@ export default function PlayerScoreInputWrapper({
 }: PlayerScoreInputWrapperProps) {
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
-  const roundsScores = useGameStore((state) =>
-    Array.isArray(state.roundsScores) ? state.roundsScores : [],
-  );
   const gameMode = useGameStore((state) => state.mode);
 
-  const lastRoundScore = useMemo(() => roundsScores.at(-1), [roundsScores]);
   const opponents = useMemo(
     () =>
       gameMode === GameMode.classic
-        ? getOpponentPlayersScore(roundPlayer, lastRoundScore?.playersScores)
-        : getOpponentTeamScore(roundPlayer, lastRoundScore?.teamsScores),
-    [gameMode, lastRoundScore?.playersScores, lastRoundScore?.teamsScores, roundPlayer],
+        ? getOpponentPlayersScore(roundPlayer, roundScore.playersScores)
+        : getOpponentTeamScore(roundPlayer, roundScore.teamsScores),
+    [gameMode, roundPlayer, roundScore.playersScores, roundScore.teamsScores],
   );
 
   return opponents?.map((opponent) => (

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
@@ -10,12 +10,14 @@ interface PlayerScoreInputWrapperProps {
   roundScore: RoundScore;
   setRoundScore: Dispatch<SetStateAction<RoundScore>>;
   roundPlayer: Player | null;
+  pointsType: string;
 }
 
 export default function PlayerScoreInputWrapper({
   roundScore,
   setRoundScore,
   roundPlayer,
+  pointsType,
 }: PlayerScoreInputWrapperProps) {
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
@@ -43,6 +45,7 @@ export default function PlayerScoreInputWrapper({
       players={players}
       teams={teams}
       roundPlayer={roundPlayer}
+      pointsType={pointsType}
     />
   ));
 }

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
@@ -1,10 +1,10 @@
 import { Dispatch, SetStateAction, useCallback, useState } from "react";
 
-import { useGameStore } from "@belot/store";
 import { useLocalization } from "@belot/localizations";
 import { RoundScore } from "@belot/types";
 import {
   calculateTotalRoundScore,
+  formatRoundPointPresetForDisplay,
   formatTotalRoundScoreForDisplay,
   getRoundPointsPresets,
 } from "@belot/utils/src";
@@ -17,10 +17,14 @@ import { VStack } from "@/components/ui/vstack";
 export interface RoundScoreSelectProps {
   roundScore: RoundScore;
   setRoundScore: Dispatch<SetStateAction<RoundScore>>;
+  pointsType: string;
 }
 
-export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundScoreSelectProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
+export default function RoundScoreSelect({
+  roundScore,
+  setRoundScore,
+  pointsType,
+}: RoundScoreSelectProps) {
   const [isPositive, setIsPositive] = useState(true);
 
   const roundScoreMsg = useLocalization("next.round.score", [
@@ -53,7 +57,7 @@ export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundSco
             onPress={() => handleRoundPointsChange(roundPoint)}
           >
             <ButtonText>
-              {operationSign} {roundPoint}
+              {operationSign} {formatRoundPointPresetForDisplay(roundPoint, pointsType)}
             </ButtonText>
           </Button>
         ))}

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
@@ -1,9 +1,13 @@
 import { Dispatch, SetStateAction, useCallback, useState } from "react";
 
-import { ROUND_POINTS } from "@belot/constants";
+import { useGameStore } from "@belot/store";
 import { useLocalization } from "@belot/localizations";
 import { RoundScore } from "@belot/types";
-import { calculateTotalRoundScore, roundToDecimal } from "@belot/utils/src";
+import {
+  calculateTotalRoundScore,
+  formatTotalRoundScoreForDisplay,
+  getRoundPointsPresets,
+} from "@belot/utils/src";
 
 import { Button, ButtonText } from "@/components/ui/button";
 import { HStack } from "@/components/ui/hstack";
@@ -16,19 +20,23 @@ export interface RoundScoreSelectProps {
 }
 
 export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundScoreSelectProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const [isPositive, setIsPositive] = useState(true);
 
   const roundScoreMsg = useLocalization("next.round.score", [
-    roundToDecimal(roundScore.totalRoundScore),
+    formatTotalRoundScoreForDisplay(roundScore.totalRoundScore, pointsType),
   ]);
 
   const operationSign = isPositive ? "+" : "-";
+  const roundPointsPresets = getRoundPointsPresets(pointsType);
 
   const handleRoundPointsChange = useCallback(
     (roundPoint: number) => {
-      setRoundScore((prev) => calculateTotalRoundScore(operationSign, roundPoint, prev));
+      setRoundScore((prev) =>
+        calculateTotalRoundScore(operationSign, roundPoint, prev, pointsType),
+      );
     },
-    [operationSign, setRoundScore],
+    [operationSign, pointsType, setRoundScore],
   );
 
   return (
@@ -37,7 +45,7 @@ export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundSco
         {roundScoreMsg}
       </Text>
       <HStack className="flex-wrap items-center justify-center gap-2.5">
-        {ROUND_POINTS.map((roundPoint) => (
+        {roundPointsPresets.map((roundPoint) => (
           <Button
             variant="solid"
             action="secondary"
@@ -45,7 +53,7 @@ export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundSco
             onPress={() => handleRoundPointsChange(roundPoint)}
           >
             <ButtonText>
-              {operationSign} {roundToDecimal(roundPoint)}
+              {operationSign} {roundPoint}
             </ButtonText>
           </Button>
         ))}

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -1,6 +1,3 @@
-import { useLocalizations } from "@belot/localizations";
-
-import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 
 import DialogPointsTypeToggle from "./dialogPointsTypeToggle";
@@ -16,8 +13,6 @@ type ScoreDialogContentProps = RoundPlayerDisplayProps &
   };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
-  const messages = useLocalizations([{ key: "next.round.score.for.player.input.helper" }]);
-
   if (!props.roundPlayer) {
     return <RoundPlayerSelect setRoundPlayer={props.setRoundPlayer} />;
   }
@@ -40,9 +35,6 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
         roundPlayer={props.roundPlayer}
         pointsType={props.dialogPointsType}
       />
-      <Text size="sm" className="text-center text-error-400">
-        {"* " + messages.nextRoundScoreForPlayerInputHelper}
-      </Text>
     </VStack>
   );
 }

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -10,6 +10,7 @@ type ScoreDialogContentProps = RoundPlayerDisplayProps &
   Pick<RoundScoreSelectProps, "roundScore" | "setRoundScore"> & {
     dialogPointsType: string;
     onDialogPointsTypeChange: (pointsType: string) => void;
+    isPointsTypeEnabled: boolean;
   };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
@@ -20,10 +21,12 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   return (
     <VStack space="md">
       <RoundPlayerDisplay roundPlayer={props.roundPlayer} setRoundPlayer={props.setRoundPlayer} />
-      <DialogPointsTypeToggle
-        value={props.dialogPointsType}
-        onChange={props.onDialogPointsTypeChange}
-      />
+      {props.isPointsTypeEnabled ? (
+        <DialogPointsTypeToggle
+          value={props.dialogPointsType}
+          onChange={props.onDialogPointsTypeChange}
+        />
+      ) : null}
       <RoundScoreSelect
         roundScore={props.roundScore}
         setRoundScore={props.setRoundScore}

--- a/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/mobile/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -3,12 +3,17 @@ import { useLocalizations } from "@belot/localizations";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 
+import DialogPointsTypeToggle from "./dialogPointsTypeToggle";
 import PlayerScoreInputWrapper from "./playerScoreInputWrapper";
 import RoundPlayerDisplay, { RoundPlayerDisplayProps } from "./roundPlayerDisplay";
 import RoundPlayerSelect from "./roundPlayerSelect";
 import RoundScoreSelect, { RoundScoreSelectProps } from "./roundScoreSelect";
 
-type ScoreDialogContentProps = RoundPlayerDisplayProps & RoundScoreSelectProps;
+type ScoreDialogContentProps = RoundPlayerDisplayProps &
+  Pick<RoundScoreSelectProps, "roundScore" | "setRoundScore"> & {
+    dialogPointsType: string;
+    onDialogPointsTypeChange: (pointsType: string) => void;
+  };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   const messages = useLocalizations([{ key: "next.round.score.for.player.input.helper" }]);
@@ -20,11 +25,20 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   return (
     <VStack space="md">
       <RoundPlayerDisplay roundPlayer={props.roundPlayer} setRoundPlayer={props.setRoundPlayer} />
-      <RoundScoreSelect roundScore={props.roundScore} setRoundScore={props.setRoundScore} />
+      <DialogPointsTypeToggle
+        value={props.dialogPointsType}
+        onChange={props.onDialogPointsTypeChange}
+      />
+      <RoundScoreSelect
+        roundScore={props.roundScore}
+        setRoundScore={props.setRoundScore}
+        pointsType={props.dialogPointsType}
+      />
       <PlayerScoreInputWrapper
         roundScore={props.roundScore}
         setRoundScore={props.setRoundScore}
         roundPlayer={props.roundPlayer}
+        pointsType={props.dialogPointsType}
       />
       <Text size="sm" className="text-center text-error-400">
         {"* " + messages.nextRoundScoreForPlayerInputHelper}

--- a/apps/mobile/components/game-table/pointCells.tsx
+++ b/apps/mobile/components/game-table/pointCells.tsx
@@ -1,4 +1,4 @@
-import { useGameStore } from "@belot/store";
+import { useEffectivePointsType } from "@belot/hooks";
 import { GameMode, RoundScore } from "@belot/types";
 import {
   formatTotalRoundScoreForDisplay,
@@ -19,7 +19,7 @@ interface PointCellsProps {
 const COMMON_CELL_CLASSNAME = "size-full py-1";
 
 export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
+  const pointsType = useEffectivePointsType();
   const scoreArray =
     gameMode === GameMode.classic ? roundScore.playersScores : roundScore.teamsScores;
 

--- a/apps/mobile/components/game-table/pointCells.tsx
+++ b/apps/mobile/components/game-table/pointCells.tsx
@@ -1,5 +1,11 @@
+import { useGameStore } from "@belot/store";
 import { GameMode, RoundScore } from "@belot/types";
-import { getCurrentScore, getCurrentScoreColor, getScore, roundToDecimal } from "@belot/utils";
+import {
+  formatTotalRoundScoreForDisplay,
+  getCurrentScore,
+  getCurrentScoreColor,
+  getScore,
+} from "@belot/utils";
 
 import { Box } from "@/components/ui/box";
 import { TableData } from "@/components/ui/table";
@@ -13,6 +19,7 @@ interface PointCellsProps {
 const COMMON_CELL_CLASSNAME = "size-full py-1";
 
 export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const scoreArray =
     gameMode === GameMode.classic ? roundScore.playersScores : roundScore.teamsScores;
 
@@ -28,8 +35,10 @@ export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
               {getScore(score)}
             </Text>
             {score.score ? (
-              <Text className={`absolute right-0.5 top-0 ${getCurrentScoreColor(score, true)}`}>
-                {getCurrentScore(score)}
+              <Text
+                className={`absolute right-0.5 top-0 ${getCurrentScoreColor(score, true, pointsType)}`}
+              >
+                {getCurrentScore(score, pointsType)}
               </Text>
             ) : null}
           </Box>
@@ -38,9 +47,7 @@ export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
       <TableData className="border-l border-primary-500 p-0">
         <Box className={`${COMMON_CELL_CLASSNAME}`}>
           <Text size="xl" bold className="text-center">
-            {String(roundScore.totalRoundScore).length === 3
-              ? roundToDecimal(roundScore.totalRoundScore)
-              : roundScore.totalRoundScore}
+            {formatTotalRoundScoreForDisplay(roundScore.totalRoundScore, pointsType)}
           </Text>
         </Box>
       </TableData>

--- a/apps/mobile/components/players-selection/actionButtons.tsx
+++ b/apps/mobile/components/players-selection/actionButtons.tsx
@@ -10,7 +10,7 @@ import { Button, ButtonText } from "@/components/ui/button";
 import { HStack } from "@/components/ui/hstack";
 
 import { getApiBaseUrl } from "@/helpers/apiBaseUrl";
-import { setMultipleItemsToStorage } from "@/helpers/storageHelpers";
+import { getFromStorage, setMultipleItemsToStorage } from "@/helpers/storageHelpers";
 
 import DealerSelectDialogContent from "./dealerSelectDialogContent";
 
@@ -39,6 +39,7 @@ function SubmitButton() {
     navigateFunction: () => router.replace("/game-table"),
     setItemsToStorage: setMultipleItemsToStorage,
     getApiBaseUrl,
+    getFromStorage,
     handleCatchError: () => {
       ToastAndroid.showWithGravity(messages.serverOffline, ToastAndroid.SHORT, ToastAndroid.CENTER);
     },

--- a/apps/mobile/components/settings/pointsTypeRadioButton.tsx
+++ b/apps/mobile/components/settings/pointsTypeRadioButton.tsx
@@ -37,9 +37,13 @@ export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButton
 
   const handleChange = useCallback(
     async (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+
       await onChange({ pointsType: newValue });
     },
-    [onChange],
+    [onChange, value],
   );
 
   return (

--- a/apps/mobile/components/settings/pointsTypeRadioButton.tsx
+++ b/apps/mobile/components/settings/pointsTypeRadioButton.tsx
@@ -1,8 +1,5 @@
-import { useCallback } from "react";
-
 import { POINTS_TYPE } from "@belot/constants";
-import { Settings } from "@belot/hooks";
-import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+import { Settings, usePointsTypeSelection } from "@belot/hooks";
 
 import ExtendedTooltip from "@/components/extendedTooltip";
 import { Button } from "@/components/ui/button";
@@ -20,31 +17,11 @@ interface PointsTypeRadioButtonProps {
 }
 
 export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButtonProps) => {
-  const messages = useLocalizations([
-    {
-      key: "settings.points.type",
-    },
-    {
-      key: "settings.points.type.hint",
-    },
-    {
-      key: "settings.points.type.micropoints",
-    },
-    {
-      key: "settings.points.type.points",
-    },
-  ]);
-
-  const handleChange = useCallback(
-    async (newValue: string) => {
-      if (newValue === value) {
-        return;
-      }
-
-      await onChange({ pointsType: newValue });
-    },
-    [onChange, value],
-  );
+  const { messages, handleChange, getOptionLabel } = usePointsTypeSelection({
+    value,
+    onChange: (newValue) => onChange({ pointsType: newValue }),
+    includeSettingsLabels: true,
+  });
 
   return (
     <VStack>
@@ -67,7 +44,7 @@ export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButton
             <RadioIndicator>
               <RadioIcon as={CircleIcon} />
             </RadioIndicator>
-            <RadioLabel>{messages[formatLocalizationKey(type.localizationKey)]}</RadioLabel>
+            <RadioLabel>{getOptionLabel(type.localizationKey)}</RadioLabel>
           </Radio>
         ))}
       </RadioGroup>

--- a/apps/mobile/hooks/starting-screen/useStartingScreenActions.ts
+++ b/apps/mobile/hooks/starting-screen/useStartingScreenActions.ts
@@ -2,7 +2,7 @@ import { useRouter } from "expo-router";
 
 import { useLoadGameData, useStartingScreenActionsHelper } from "@belot/hooks";
 
-import { getFromStorage, removeFromStorage } from "@/helpers/storageHelpers";
+import { getFromStorage, removeFromStorage, setToStorage } from "@/helpers/storageHelpers";
 
 interface StartingScreenAction {
   index: number;
@@ -16,6 +16,7 @@ export const useStartingScreenActions = (): StartingScreenAction[] => {
 
   const gameData = useLoadGameData({
     getFromStorage,
+    setToStorage,
     shouldSetData: false,
   });
 

--- a/apps/mobile/hooks/useReadInitialTheme.ts
+++ b/apps/mobile/hooks/useReadInitialTheme.ts
@@ -1,8 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useColorScheme } from "react-native";
-
-import { useFocusEffect } from "expo-router";
 
 import { StorageKeys, THEMES } from "@belot/constants";
 
@@ -20,11 +18,9 @@ export const useReadInitialTheme = () => {
     setTheme(initial);
   }, [systemColorScheme]);
 
-  useFocusEffect(
-    useCallback(() => {
-      readInitialTheme();
-    }, [readInitialTheme]),
-  );
+  useEffect(() => {
+    void readInitialTheme();
+  }, [readInitialTheme]);
 
   return { theme };
 };

--- a/apps/mobile/tests/app/_layout.test.tsx
+++ b/apps/mobile/tests/app/_layout.test.tsx
@@ -13,8 +13,8 @@ vi.mock("@/helpers/localization", () => ({
   getDeviceLanguage: () => "en",
 }));
 
-vi.mock("@/components/navigation", () => ({
-  default: () => <div>Navigation</div>,
+vi.mock("expo-router", () => ({
+  Stack: () => <div>Expo Stack</div>,
 }));
 
 vi.mock("@belot/components", () => ({
@@ -26,10 +26,10 @@ vi.mock("@belot/localizations", () => ({
 }));
 
 describe("RootLayout", () => {
-  it("renders navigation inside providers", async () => {
+  it("renders expo stack inside providers", async () => {
     const { default: RootLayout } = await import("@/app/_layout");
     render(<RootLayout />);
 
-    expect(screen.getByText("Navigation")).toBeTruthy();
+    expect(screen.getByText("Expo Stack")).toBeTruthy();
   });
 });

--- a/apps/mobile/tests/app/settings-screen.test.tsx
+++ b/apps/mobile/tests/app/settings-screen.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   settings: { pointsType: "points" },
   setSettings: vi.fn(),
   getSettingsFromLocalStorage: vi.fn(),
+  isPointsTypeEnabled: true,
 }));
 
 vi.mock("@belot/hooks", () => ({
@@ -15,6 +16,7 @@ vi.mock("@belot/hooks", () => ({
     setSettings: mocks.setSettings,
     getSettingsFromLocalStorage: mocks.getSettingsFromLocalStorage,
   }),
+  useIsPointsTypeEnabled: () => mocks.isPointsTypeEnabled,
 }));
 
 vi.mock("@belot/localizations", () => ({
@@ -34,7 +36,12 @@ vi.mock("@/components/settings/pointsTypeRadioButton", () => ({
 }));
 
 describe("SettingsScreen", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders settings screen", async () => {
+    mocks.isPointsTypeEnabled = true;
     const { default: SettingsScreen } = await import("@/app/settings-screen");
     render(<SettingsScreen />);
 
@@ -42,5 +49,13 @@ describe("SettingsScreen", () => {
     expect(screen.getByRole("heading", { name: "Settings" })).toBeTruthy();
     expect(screen.getByText("PointsType")).toBeTruthy();
     expect(mocks.getSettingsFromLocalStorage).toHaveBeenCalled();
+  });
+
+  it("hides points type settings when feature is disabled", async () => {
+    mocks.isPointsTypeEnabled = false;
+    const { default: SettingsScreen } = await import("@/app/settings-screen");
+    render(<SettingsScreen />);
+
+    expect(screen.queryByText("PointsType")).toBeNull();
   });
 });

--- a/apps/mobile/tests/components/game-table/gameTable.test.tsx
+++ b/apps/mobile/tests/components/game-table/gameTable.test.tsx
@@ -96,6 +96,7 @@ vi.mock("@belot/hooks", () => ({
   useGetTableHeaderDealerBackground: () => ({
     getDealerBackground: () => "",
   }),
+  useEffectivePointsType: () => "micropoints",
 }));
 
 vi.mock("@/hooks/game-table/useGetPlayersNamesWithScoreColumn", () => ({

--- a/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
@@ -24,15 +24,22 @@ const mocks = vi.hoisted(() => ({
   gameMode: "classic" as "classic" | "teams",
 }));
 
-vi.mock("@belot/localizations", () => ({
-  useLocalization: (key: string, args?: string[]) =>
-    args ? `${key}:${args.join(",")}` : key,
-  useLocalizations: () => ({
-    nextRoundScoreForPlayerInputHelper: "helper",
-    nextRoundScoreForPlayer: "Score for {0}",
-  }),
-  formatLocalizationString: (msg: string, args: string[]) => `${msg}:${args[0]}`,
-}));
+vi.mock("@belot/localizations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@belot/localizations")>();
+
+  return {
+    ...actual,
+    useLocalization: (key: string, args?: string[]) =>
+      args ? `${key}:${args.join(",")}` : key,
+    useLocalizations: () => ({
+      nextRoundScoreForPlayerInputHelper: "helper",
+      nextRoundScoreForPlayer: "Score for {0}",
+      settingsPointsTypeMicropoints: "Micropoints",
+      settingsPointsTypePoints: "Points",
+    }),
+    formatLocalizationString: (msg: string, args: string[]) => `${msg}:${args[0]}`,
+  };
+});
 
 vi.mock("@belot/store", () => ({
   useGameStore: (selector: (state: Record<string, unknown>) => unknown) =>
@@ -98,12 +105,18 @@ describe("next-round-button components", () => {
       roundPlayer: null,
     };
 
-    render(<RoundScoreSelect roundScore={roundScore} setRoundScore={setRoundScore} />);
-    fireEvent.click(screen.getByText("+ 20"));
+    render(
+      <RoundScoreSelect
+        roundScore={roundScore}
+        setRoundScore={setRoundScore}
+        pointsType="micropoints"
+      />,
+    );
+    fireEvent.click(screen.getByText("+ 2"));
     expect(setRoundScore).toHaveBeenCalled();
 
     fireEvent.click(screen.getByText("+"));
-    fireEvent.click(screen.getByText("- 20"));
+    fireEvent.click(screen.getByText("- 2"));
     expect(setRoundScore).toHaveBeenCalled();
   });
 
@@ -120,6 +133,8 @@ describe("next-round-button components", () => {
           roundPlayer: null,
         }}
         setRoundScore={vi.fn()}
+        dialogPointsType="micropoints"
+        onDialogPointsTypeChange={vi.fn()}
       />,
     );
 
@@ -139,6 +154,8 @@ describe("next-round-button components", () => {
           roundPlayer: mocks.players[0],
         }}
         setRoundScore={vi.fn()}
+        dialogPointsType="micropoints"
+        onDialogPointsTypeChange={vi.fn()}
       />,
     );
 
@@ -157,6 +174,7 @@ describe("next-round-button components", () => {
           roundPlayer: mocks.players[0],
         }}
         setRoundScore={vi.fn()}
+        pointsType="micropoints"
       />,
     );
 

--- a/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
@@ -32,7 +32,6 @@ vi.mock("@belot/localizations", async (importOriginal) => {
     useLocalization: (key: string, args?: string[]) =>
       args ? `${key}:${args.join(",")}` : key,
     useLocalizations: () => ({
-      nextRoundScoreForPlayerInputHelper: "helper",
       nextRoundScoreForPlayer: "Score for {0}",
       settingsPointsTypeMicropoints: "Micropoints",
       settingsPointsTypePoints: "Points",
@@ -159,7 +158,8 @@ describe("next-round-button components", () => {
       />,
     );
 
-    expect(screen.getByText("* helper")).toBeTruthy();
+    expect(screen.getByText("next.round.score:16")).toBeTruthy();
+    expect(screen.getByText("Score for {0}:Bob")).toBeTruthy();
   });
 
   it("PlayerScoreInputWrapper renders opponent inputs", () => {

--- a/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
@@ -148,7 +148,10 @@ describe("next-round-button components", () => {
         setRoundPlayer={vi.fn()}
         roundScore={{
           id: 0,
-          playersScores: [],
+          playersScores: [
+            { id: 0, playerId: 0, score: 0, boltCount: 0, totalScore: 0 },
+            { id: 1, playerId: 1, score: 0, boltCount: 0, totalScore: 0 },
+          ],
           teamsScores: [],
           totalRoundScore: 162,
           roundPlayer: mocks.players[0],
@@ -170,7 +173,10 @@ describe("next-round-button components", () => {
         roundPlayer={mocks.players[0]}
         roundScore={{
           id: 0,
-          playersScores: [],
+          playersScores: [
+            { id: 0, playerId: 0, score: 0, boltCount: 0, totalScore: 0 },
+            { id: 1, playerId: 1, score: 0, boltCount: 0, totalScore: 0 },
+          ],
           teamsScores: [],
           totalRoundScore: 162,
           roundPlayer: mocks.players[0],

--- a/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
@@ -134,6 +134,7 @@ describe("next-round-button components", () => {
         setRoundScore={vi.fn()}
         dialogPointsType="micropoints"
         onDialogPointsTypeChange={vi.fn()}
+        isPointsTypeEnabled={false}
       />,
     );
 
@@ -155,6 +156,7 @@ describe("next-round-button components", () => {
         setRoundScore={vi.fn()}
         dialogPointsType="micropoints"
         onDialogPointsTypeChange={vi.fn()}
+        isPointsTypeEnabled={false}
       />,
     );
 

--- a/apps/mobile/tests/components/game-table/playerScoreInput.test.tsx
+++ b/apps/mobile/tests/components/game-table/playerScoreInput.test.tsx
@@ -34,6 +34,7 @@ describe("PlayerScoreInput", () => {
         ]}
         teams={[]}
         roundPlayer={{ id: 0, name: "Alice" }}
+        pointsType="micropoints"
       />,
     );
 
@@ -63,6 +64,7 @@ describe("PlayerScoreInput", () => {
         ]}
         teams={[]}
         roundPlayer={{ id: 0, name: "Alice" }}
+        pointsType="micropoints"
       />,
     );
 

--- a/apps/mobile/tests/components/game-table/playerScoreInputTeam.test.tsx
+++ b/apps/mobile/tests/components/game-table/playerScoreInputTeam.test.tsx
@@ -29,6 +29,7 @@ describe("PlayerScoreInput team mode", () => {
         players={[]}
         teams={[{ id: 0, name: "Team A", playersIds: [0] }]}
         roundPlayer={{ id: 0, name: "Alice" }}
+        pointsType="micropoints"
       />,
     );
 

--- a/apps/mobile/tests/hooks/starting-screen/useStartingScreenActions.test.ts
+++ b/apps/mobile/tests/hooks/starting-screen/useStartingScreenActions.test.ts
@@ -29,6 +29,7 @@ vi.mock("@belot/hooks", () => ({
 vi.mock("@/helpers/storageHelpers", () => ({
   getFromStorage: vi.fn(),
   removeFromStorage: vi.fn(),
+  setToStorage: vi.fn(),
 }));
 
 describe("useStartingScreenActions", () => {

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+
+import { POINTS_TYPE } from "@belot/constants";
+import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+interface DialogPointsTypeToggleProps {
+  value: string;
+  onChange: (pointsType: string) => void;
+}
+
+export default function DialogPointsTypeToggle({ value, onChange }: DialogPointsTypeToggleProps) {
+  const messages = useLocalizations([
+    {
+      key: "settings.points.type.micropoints",
+    },
+    {
+      key: "settings.points.type.points",
+    },
+  ]);
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      onChange(newValue);
+    },
+    [onChange],
+  );
+
+  return (
+    <RadioGroup
+      value={value}
+      onValueChange={handleChange}
+      className="flex items-center justify-center gap-4"
+    >
+      {POINTS_TYPE.map((type) => (
+        <div key={type.id} className="flex items-center gap-2">
+          <RadioGroupItem value={type.id} id={`dialog-points-type-${type.id}`} />
+          <Label htmlFor={`dialog-points-type-${type.id}`}>
+            {messages[formatLocalizationKey(type.localizationKey)]}
+          </Label>
+        </div>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -23,9 +23,13 @@ export default function DialogPointsTypeToggle({ value, onChange }: DialogPoints
 
   const handleChange = useCallback(
     (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+
       onChange(newValue);
     },
-    [onChange],
+    [onChange, value],
   );
 
   return (

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle.tsx
@@ -1,7 +1,5 @@
-import { useCallback } from "react";
-
 import { POINTS_TYPE } from "@belot/constants";
-import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+import { usePointsTypeSelection } from "@belot/hooks";
 
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -12,25 +10,7 @@ interface DialogPointsTypeToggleProps {
 }
 
 export default function DialogPointsTypeToggle({ value, onChange }: DialogPointsTypeToggleProps) {
-  const messages = useLocalizations([
-    {
-      key: "settings.points.type.micropoints",
-    },
-    {
-      key: "settings.points.type.points",
-    },
-  ]);
-
-  const handleChange = useCallback(
-    (newValue: string) => {
-      if (newValue === value) {
-        return;
-      }
-
-      onChange(newValue);
-    },
-    [onChange, value],
-  );
+  const { handleChange, getOptionLabel } = usePointsTypeSelection({ value, onChange });
 
   return (
     <RadioGroup
@@ -42,7 +22,7 @@ export default function DialogPointsTypeToggle({ value, onChange }: DialogPoints
         <div key={type.id} className="flex items-center gap-2">
           <RadioGroupItem value={type.id} id={`dialog-points-type-${type.id}`} />
           <Label htmlFor={`dialog-points-type-${type.id}`}>
-            {messages[formatLocalizationKey(type.localizationKey)]}
+            {getOptionLabel(type.localizationKey)}
           </Label>
         </div>
       ))}

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
 
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import {
@@ -67,11 +67,36 @@ export default function PlayerScoreInput({
     [gameMode, opponent, roundPlayer, setRoundScore],
   );
 
+  const lastSyncedScoreRef = useRef<{
+    opponentId: number;
+    totalRoundScore: number;
+    score: number;
+  } | null>(null);
+
   useEffect(() => {
-    if (roundScore.totalRoundScore) {
-      handleInputChange(finalRoundScore?.score || 0);
+    if (!roundScore.totalRoundScore) {
+      lastSyncedScoreRef.current = null;
+      return;
     }
-  }, [finalRoundScore?.score, handleInputChange, roundScore.totalRoundScore]);
+
+    const targetScore = finalRoundScore?.score ?? 0;
+    const lastSyncedScore = lastSyncedScoreRef.current;
+
+    if (
+      lastSyncedScore?.opponentId === opponent.id &&
+      lastSyncedScore.totalRoundScore === roundScore.totalRoundScore &&
+      lastSyncedScore.score === targetScore
+    ) {
+      return;
+    }
+
+    handleInputChange(targetScore);
+    lastSyncedScoreRef.current = {
+      opponentId: opponent.id,
+      totalRoundScore: roundScore.totalRoundScore,
+      score: targetScore,
+    };
+  }, [finalRoundScore?.score, handleInputChange, opponent.id, roundScore.totalRoundScore]);
 
   return (
     <Field>

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo } from "react";
 
+import { useGameStore } from "@belot/store";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import {
   GameMode,
@@ -9,7 +10,7 @@ import {
   type Team,
   type TeamScore,
 } from "@belot/types";
-import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode } from "@belot/utils/src";
+import { handleRoundScoreChange, prepareRoundScoresBasedOnGameMode, getScoreInputMaxLength } from "@belot/utils/src";
 
 import { Field, FieldLabel } from "@/components/ui/field";
 import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
@@ -33,6 +34,7 @@ export default function PlayerScoreInput({
   teams,
   roundPlayer,
 }: PlayerScoreInputProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const messages = useLocalizations([{ key: "next.round.score.for.player" }]);
 
   const finalRoundScore = useMemo(
@@ -79,7 +81,7 @@ export default function PlayerScoreInput({
           id={`${opponent.id}`}
           className="[-moz-appearance:textfield] [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
           value={String(finalRoundScore?.score || 0)}
-          maxLength={3}
+          maxLength={getScoreInputMaxLength(pointsType)}
           type="number"
           onChange={(e) => handleInputChange(Number(e.target.value))}
           onFocus={(e) => {

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,5 +1,6 @@
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useMemo } from "react";
 
+import { useSyncPlayerScoreInput } from "@belot/hooks";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import {
   GameMode,
@@ -67,36 +68,12 @@ export default function PlayerScoreInput({
     [gameMode, opponent, roundPlayer, setRoundScore],
   );
 
-  const lastSyncedScoreRef = useRef<{
-    opponentId: number;
-    totalRoundScore: number;
-    score: number;
-  } | null>(null);
-
-  useEffect(() => {
-    if (!roundScore.totalRoundScore) {
-      lastSyncedScoreRef.current = null;
-      return;
-    }
-
-    const targetScore = finalRoundScore?.score ?? 0;
-    const lastSyncedScore = lastSyncedScoreRef.current;
-
-    if (
-      lastSyncedScore?.opponentId === opponent.id &&
-      lastSyncedScore.totalRoundScore === roundScore.totalRoundScore &&
-      lastSyncedScore.score === targetScore
-    ) {
-      return;
-    }
-
-    handleInputChange(targetScore);
-    lastSyncedScoreRef.current = {
-      opponentId: opponent.id,
-      totalRoundScore: roundScore.totalRoundScore,
-      score: targetScore,
-    };
-  }, [finalRoundScore?.score, handleInputChange, opponent.id, roundScore.totalRoundScore]);
+  useSyncPlayerScoreInput({
+    opponentId: opponent.id,
+    totalRoundScore: roundScore.totalRoundScore,
+    targetScore: finalRoundScore?.score ?? 0,
+    onScoreChange: handleInputChange,
+  });
 
   return (
     <Field>

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInput.tsx
@@ -1,6 +1,5 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo } from "react";
 
-import { useGameStore } from "@belot/store";
 import { formatLocalizationString, useLocalizations } from "@belot/localizations";
 import {
   GameMode,
@@ -23,6 +22,7 @@ interface PlayerScoreInputProps {
   players: Player[];
   teams: Team[];
   roundPlayer: Player | null;
+  pointsType: string;
 }
 
 export default function PlayerScoreInput({
@@ -33,8 +33,8 @@ export default function PlayerScoreInput({
   players,
   teams,
   roundPlayer,
+  pointsType,
 }: PlayerScoreInputProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
   const messages = useLocalizations([{ key: "next.round.score.for.player" }]);
 
   const finalRoundScore = useMemo(

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
@@ -21,16 +21,14 @@ export default function PlayerScoreInputWrapper({
 }: PlayerScoreInputWrapperProps) {
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
-  const roundsScores = useGameStore((state) => state.roundsScores);
   const gameMode = useGameStore((state) => state.mode);
 
-  const lastRoundScore = useMemo(() => roundsScores.at(-1), [roundsScores]);
   const opponents = useMemo(
     () =>
       gameMode === GameMode.classic
-        ? getOpponentPlayersScore(roundPlayer, lastRoundScore?.playersScores)
-        : getOpponentTeamScore(roundPlayer, lastRoundScore?.teamsScores),
-    [gameMode, lastRoundScore?.playersScores, lastRoundScore?.teamsScores, roundPlayer],
+        ? getOpponentPlayersScore(roundPlayer, roundScore.playersScores)
+        : getOpponentTeamScore(roundPlayer, roundScore.teamsScores),
+    [gameMode, roundPlayer, roundScore.playersScores, roundScore.teamsScores],
   );
 
   return (

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.tsx
@@ -10,12 +10,14 @@ interface PlayerScoreInputWrapperProps {
   roundScore: RoundScore;
   setRoundScore: Dispatch<SetStateAction<RoundScore>>;
   roundPlayer: Player | null;
+  pointsType: string;
 }
 
 export default function PlayerScoreInputWrapper({
   roundScore,
   setRoundScore,
   roundPlayer,
+  pointsType,
 }: PlayerScoreInputWrapperProps) {
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
@@ -43,6 +45,7 @@ export default function PlayerScoreInputWrapper({
           players={players}
           teams={teams}
           roundPlayer={roundPlayer}
+          pointsType={pointsType}
         />
       ))}
     </div>

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
@@ -1,10 +1,10 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
 
-import { useGameStore } from "@belot/store";
 import { useLocalization } from "@belot/localizations";
 import { type RoundScore } from "@belot/types";
 import {
   calculateTotalRoundScore,
+  formatRoundPointPresetForDisplay,
   formatTotalRoundScoreForDisplay,
   getRoundPointsPresets,
 } from "@belot/utils/src";
@@ -14,10 +14,14 @@ import { Button } from "@/components/ui/button";
 export interface RoundScoreSelectProps {
   roundScore: RoundScore;
   setRoundScore: Dispatch<SetStateAction<RoundScore>>;
+  pointsType: string;
 }
 
-export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundScoreSelectProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
+export default function RoundScoreSelect({
+  roundScore,
+  setRoundScore,
+  pointsType,
+}: RoundScoreSelectProps) {
   const [isPositive, setIsPositive] = useState(true);
 
   const roundScoreMsg = useLocalization("next.round.score", [
@@ -46,7 +50,7 @@ export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundSco
             variant="secondary"
             onClick={() => handleRoundPointsChange(roundPoint)}
           >
-            {operationSign} {roundPoint}
+            {operationSign} {formatRoundPointPresetForDisplay(roundPoint, pointsType)}
           </Button>
         ))}
         <Button variant="outline" onClick={() => setIsPositive(!isPositive)}>

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/roundScoreSelect.tsx
@@ -1,9 +1,13 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
 
-import { ROUND_POINTS } from "@belot/constants";
+import { useGameStore } from "@belot/store";
 import { useLocalization } from "@belot/localizations";
 import { type RoundScore } from "@belot/types";
-import { calculateTotalRoundScore, roundToDecimal } from "@belot/utils/src";
+import {
+  calculateTotalRoundScore,
+  formatTotalRoundScoreForDisplay,
+  getRoundPointsPresets,
+} from "@belot/utils/src";
 
 import { Button } from "@/components/ui/button";
 
@@ -13,32 +17,36 @@ export interface RoundScoreSelectProps {
 }
 
 export default function RoundScoreSelect({ roundScore, setRoundScore }: RoundScoreSelectProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const [isPositive, setIsPositive] = useState(true);
 
   const roundScoreMsg = useLocalization("next.round.score", [
-    roundToDecimal(roundScore.totalRoundScore),
+    formatTotalRoundScoreForDisplay(roundScore.totalRoundScore, pointsType),
   ]);
 
   const operationSign = isPositive ? "+" : "-";
+  const roundPointsPresets = getRoundPointsPresets(pointsType);
 
   const handleRoundPointsChange = useCallback(
     (roundPoint: number) => {
-      setRoundScore((prev) => calculateTotalRoundScore(operationSign, roundPoint, prev));
+      setRoundScore((prev) =>
+        calculateTotalRoundScore(operationSign, roundPoint, prev, pointsType),
+      );
     },
-    [operationSign, setRoundScore],
+    [operationSign, pointsType, setRoundScore],
   );
 
   return (
     <div className="flex flex-col gap-1">
       <span className="text-center text-xl">{roundScoreMsg}</span>
       <div className="flex flex-wrap items-center justify-center gap-2.5">
-        {ROUND_POINTS.map((roundPoint) => (
+        {roundPointsPresets.map((roundPoint) => (
           <Button
             key={roundPoint}
             variant="secondary"
             onClick={() => handleRoundPointsChange(roundPoint)}
           >
-            {operationSign} {roundToDecimal(roundPoint)}
+            {operationSign} {roundPoint}
           </Button>
         ))}
         <Button variant="outline" onClick={() => setIsPositive(!isPositive)}>

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -1,5 +1,3 @@
-import { useLocalizations } from "@belot/localizations";
-
 import DialogPointsTypeToggle from "./dialogPointsTypeToggle";
 import PlayerScoreInputWrapper from "./playerScoreInputWrapper";
 import RoundPlayerDisplay, { type RoundPlayerDisplayProps } from "./roundPlayerDisplay";
@@ -13,8 +11,6 @@ type ScoreDialogContentProps = RoundPlayerDisplayProps &
   };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
-  const messages = useLocalizations([{ key: "next.round.score.for.player.input.helper" }]);
-
   if (!props.roundPlayer) {
     return <RoundPlayerSelect setRoundPlayer={props.setRoundPlayer} />;
   }
@@ -37,9 +33,6 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
         roundPlayer={props.roundPlayer}
         pointsType={props.dialogPointsType}
       />
-      <span className="text-error-400 text-center">
-        {"* " + messages.nextRoundScoreForPlayerInputHelper}
-      </span>
     </div>
   );
 }

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -8,6 +8,7 @@ type ScoreDialogContentProps = RoundPlayerDisplayProps &
   Pick<RoundScoreSelectProps, "roundScore" | "setRoundScore"> & {
     dialogPointsType: string;
     onDialogPointsTypeChange: (pointsType: string) => void;
+    isPointsTypeEnabled: boolean;
   };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
@@ -18,10 +19,12 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   return (
     <div className="flex flex-col gap-2.5">
       <RoundPlayerDisplay roundPlayer={props.roundPlayer} setRoundPlayer={props.setRoundPlayer} />
-      <DialogPointsTypeToggle
-        value={props.dialogPointsType}
-        onChange={props.onDialogPointsTypeChange}
-      />
+      {props.isPointsTypeEnabled ? (
+        <DialogPointsTypeToggle
+          value={props.dialogPointsType}
+          onChange={props.onDialogPointsTypeChange}
+        />
+      ) : null}
       <RoundScoreSelect
         roundScore={props.roundScore}
         setRoundScore={props.setRoundScore}

--- a/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
+++ b/apps/web/src/components/game-table/action-buttons/next-round-button/scoreDialogContent.tsx
@@ -1,11 +1,16 @@
 import { useLocalizations } from "@belot/localizations";
 
+import DialogPointsTypeToggle from "./dialogPointsTypeToggle";
 import PlayerScoreInputWrapper from "./playerScoreInputWrapper";
 import RoundPlayerDisplay, { type RoundPlayerDisplayProps } from "./roundPlayerDisplay";
 import RoundPlayerSelect from "./roundPlayerSelect";
 import RoundScoreSelect, { type RoundScoreSelectProps } from "./roundScoreSelect";
 
-type ScoreDialogContentProps = RoundPlayerDisplayProps & RoundScoreSelectProps;
+type ScoreDialogContentProps = RoundPlayerDisplayProps &
+  Pick<RoundScoreSelectProps, "roundScore" | "setRoundScore"> & {
+    dialogPointsType: string;
+    onDialogPointsTypeChange: (pointsType: string) => void;
+  };
 
 export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   const messages = useLocalizations([{ key: "next.round.score.for.player.input.helper" }]);
@@ -17,11 +22,20 @@ export default function ScoreDialogContent(props: ScoreDialogContentProps) {
   return (
     <div className="flex flex-col gap-2.5">
       <RoundPlayerDisplay roundPlayer={props.roundPlayer} setRoundPlayer={props.setRoundPlayer} />
-      <RoundScoreSelect roundScore={props.roundScore} setRoundScore={props.setRoundScore} />
+      <DialogPointsTypeToggle
+        value={props.dialogPointsType}
+        onChange={props.onDialogPointsTypeChange}
+      />
+      <RoundScoreSelect
+        roundScore={props.roundScore}
+        setRoundScore={props.setRoundScore}
+        pointsType={props.dialogPointsType}
+      />
       <PlayerScoreInputWrapper
         roundScore={props.roundScore}
         setRoundScore={props.setRoundScore}
         roundPlayer={props.roundPlayer}
+        pointsType={props.dialogPointsType}
       />
       <span className="text-error-400 text-center">
         {"* " + messages.nextRoundScoreForPlayerInputHelper}

--- a/apps/web/src/components/game-table/pointCells.tsx
+++ b/apps/web/src/components/game-table/pointCells.tsx
@@ -1,5 +1,11 @@
+import { useGameStore } from "@belot/store";
 import { GameMode, type RoundScore } from "@belot/types";
-import { getCurrentScore, getCurrentScoreColor, getScore, roundToDecimal } from "@belot/utils/src";
+import {
+  formatTotalRoundScoreForDisplay,
+  getCurrentScore,
+  getCurrentScoreColor,
+  getScore,
+} from "@belot/utils/src";
 
 import { TableCell } from "@/components/ui/table";
 
@@ -8,8 +14,11 @@ interface PointCellsProps {
   gameMode: GameMode;
 }
 
-const getWebCurrentScoreColor = (score: Parameters<typeof getCurrentScoreColor>[0]) => {
-  const color = getCurrentScoreColor(score);
+const getWebCurrentScoreColor = (
+  score: Parameters<typeof getCurrentScoreColor>[0],
+  pointsType: string,
+) => {
+  const color = getCurrentScoreColor(score, false, pointsType);
 
   if (color === "text-success") return "text-success";
   if (color === "text-destructive") return "text-destructive";
@@ -18,6 +27,7 @@ const getWebCurrentScoreColor = (score: Parameters<typeof getCurrentScoreColor>[
 };
 
 export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
+  const pointsType = useGameStore((state) => state.pointsType);
   const scoreArray =
     gameMode === GameMode.classic ? roundScore.playersScores : roundScore.teamsScores;
 
@@ -32,8 +42,10 @@ export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
             <span className="text-xl">{getScore(score)}</span>
           </div>
           {score.score ? (
-            <span className={`absolute top-0 right-0.5 text-xs ${getWebCurrentScoreColor(score)}`}>
-              {getCurrentScore(score)}
+            <span
+              className={`absolute top-0 right-0.5 text-xs ${getWebCurrentScoreColor(score, pointsType)}`}
+            >
+              {getCurrentScore(score, pointsType)}
             </span>
           ) : null}
         </TableCell>
@@ -41,9 +53,7 @@ export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
       <TableCell className="border-primary flex flex-1 border-l p-0">
         <div className="flex size-full items-center justify-center p-0">
           <span className="text-xl font-bold">
-            {String(roundScore.totalRoundScore).length === 3
-              ? roundToDecimal(roundScore.totalRoundScore)
-              : roundScore.totalRoundScore}
+            {formatTotalRoundScoreForDisplay(roundScore.totalRoundScore, pointsType)}
           </span>
         </div>
       </TableCell>

--- a/apps/web/src/components/game-table/pointCells.tsx
+++ b/apps/web/src/components/game-table/pointCells.tsx
@@ -1,4 +1,4 @@
-import { useGameStore } from "@belot/store";
+import { useEffectivePointsType } from "@belot/hooks";
 import { GameMode, type RoundScore } from "@belot/types";
 import {
   formatTotalRoundScoreForDisplay,
@@ -27,7 +27,7 @@ const getWebCurrentScoreColor = (
 };
 
 export default function PointCells({ roundScore, gameMode }: PointCellsProps) {
-  const pointsType = useGameStore((state) => state.pointsType);
+  const pointsType = useEffectivePointsType();
   const scoreArray =
     gameMode === GameMode.classic ? roundScore.playersScores : roundScore.teamsScores;
 

--- a/apps/web/src/components/players-selection/actionButtons.tsx
+++ b/apps/web/src/components/players-selection/actionButtons.tsx
@@ -8,7 +8,7 @@ import ConfirmationDialog from "@/components/confirmationDialog";
 import { Button } from "@/components/ui/button";
 
 import { getApiBaseUrl } from "@/helpers/apiBaseUrl";
-import { setMultipleItemsToStorage } from "@/helpers/storageHelpers";
+import { getFromStorage, setMultipleItemsToStorage } from "@/helpers/storageHelpers";
 
 import { toast } from "sonner";
 
@@ -39,6 +39,7 @@ function SubmitButton() {
     navigateFunction: () => void navigate("/game-table", { replace: true }),
     setItemsToStorage: setMultipleItemsToStorage,
     getApiBaseUrl,
+    getFromStorage,
     handleCatchError: () => {
       toast.error(messages.serverOffline);
     },

--- a/apps/web/src/components/settings/pointsTypeRadioButton.tsx
+++ b/apps/web/src/components/settings/pointsTypeRadioButton.tsx
@@ -35,9 +35,13 @@ export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButton
 
   const handleChange = useCallback(
     async (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+
       await onChange({ pointsType: newValue });
     },
-    [onChange],
+    [onChange, value],
   );
 
   return (

--- a/apps/web/src/components/settings/pointsTypeRadioButton.tsx
+++ b/apps/web/src/components/settings/pointsTypeRadioButton.tsx
@@ -1,8 +1,5 @@
-import { useCallback } from "react";
-
 import { POINTS_TYPE } from "@belot/constants";
-import type { Settings } from "@belot/hooks";
-import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+import { type Settings, usePointsTypeSelection } from "@belot/hooks";
 
 import { Button } from "@/components/ui/button";
 import { FieldLegend, FieldSet } from "@/components/ui/field";
@@ -18,31 +15,11 @@ interface PointsTypeRadioButtonProps {
 }
 
 export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButtonProps) => {
-  const messages = useLocalizations([
-    {
-      key: "settings.points.type",
-    },
-    {
-      key: "settings.points.type.hint",
-    },
-    {
-      key: "settings.points.type.micropoints",
-    },
-    {
-      key: "settings.points.type.points",
-    },
-  ]);
-
-  const handleChange = useCallback(
-    async (newValue: string) => {
-      if (newValue === value) {
-        return;
-      }
-
-      await onChange({ pointsType: newValue });
-    },
-    [onChange, value],
-  );
+  const { messages, handleChange, getOptionLabel } = usePointsTypeSelection({
+    value,
+    onChange: (newValue) => onChange({ pointsType: newValue }),
+    includeSettingsLabels: true,
+  });
 
   return (
     <FieldSet className="w-full max-w-xs">
@@ -66,7 +43,7 @@ export const PointsTypeRadioButton = ({ value, onChange }: PointsTypeRadioButton
         {POINTS_TYPE.map((type) => (
           <div key={type.id} className="flex items-center gap-3">
             <RadioGroupItem value={type.id} id={type.id} />
-            <Label htmlFor={type.id}>{messages[formatLocalizationKey(type.localizationKey)]}</Label>
+            <Label htmlFor={type.id}>{getOptionLabel(type.localizationKey)}</Label>
           </div>
         ))}
       </RadioGroup>

--- a/apps/web/src/hooks/starting-screen/useStartingScreenActions.ts
+++ b/apps/web/src/hooks/starting-screen/useStartingScreenActions.ts
@@ -2,6 +2,8 @@ import { useNavigate } from "react-router-dom";
 
 import { useLoadGameData, useStartingScreenActionsHelper } from "@belot/hooks";
 
+import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
+
 interface StartingScreenAction {
   index: number;
   label: string;
@@ -13,7 +15,8 @@ export const useStartingScreenActions = (): StartingScreenAction[] => {
   const navigate = useNavigate();
 
   const gameData = useLoadGameData({
-    getFromStorage: (key) => localStorage.getItem(key),
+    getFromStorage,
+    setToStorage,
     shouldSetData: false,
   });
 

--- a/apps/web/src/pages/game-table.tsx
+++ b/apps/web/src/pages/game-table.tsx
@@ -3,9 +3,10 @@ import { useLoadGameData } from "@belot/hooks";
 import GameTable from "@/components/game-table";
 import Header from "@/components/game-table/header";
 import { Separator } from "@/components/ui/separator";
+import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
 
 export default function GameTablePage() {
-  useLoadGameData({ getFromStorage: (key) => localStorage.getItem(key) });
+  useLoadGameData({ getFromStorage, setToStorage });
 
   return (
     <div className="relative flex h-full flex-col">

--- a/apps/web/src/pages/settings.tsx
+++ b/apps/web/src/pages/settings.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect } from "react";
 
-import { useSettings } from "@belot/hooks";
+import { useSettings, useIsPointsTypeEnabled } from "@belot/hooks";
 import { useLocalization } from "@belot/localizations";
 
 import { BackButton } from "@/components/backButton";
@@ -9,6 +9,7 @@ import { PointsTypeRadioButton } from "@/components/settings/pointsTypeRadioButt
 
 export default function SettingsPage() {
   const settingsMsg = useLocalization("settings");
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
   const getFromStorage = useCallback((key: string) => localStorage.getItem(key), []);
   const setToStorage = useCallback(
     (key: string, value: string) => localStorage.setItem(key, value),
@@ -30,7 +31,9 @@ export default function SettingsPage() {
       <PageHeader title={settingsMsg} />
 
       <div className="flex flex-1 flex-col items-center justify-center gap-4">
-        <PointsTypeRadioButton value={settings.pointsType} onChange={setSettings} />
+        {isPointsTypeEnabled ? (
+          <PointsTypeRadioButton value={settings.pointsType} onChange={setSettings} />
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInput.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInput.test.tsx
@@ -38,6 +38,7 @@ describe("PlayerScoreInput", () => {
           ]}
           teams={[]}
           roundPlayer={{ id: 0, name: "Alice" }}
+          pointsType="micropoints"
         />
       );
     }
@@ -71,6 +72,7 @@ describe("PlayerScoreInput", () => {
           players={[]}
           teams={[{ id: 1, name: "Team B", playersIds: [0, 1] }] as Team[]}
           roundPlayer={{ id: 0, name: "Alice" }}
+          pointsType="micropoints"
         />
       );
     }

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
@@ -58,6 +58,7 @@ describe("PlayerScoreInputWrapper teams mode", () => {
           roundScore={roundScore}
           setRoundScore={setRoundScore}
           roundPlayer={{ id: 0, name: "Alice", teamId: 0 }}
+          pointsType="micropoints"
         />
       );
     }

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
@@ -49,7 +49,10 @@ describe("PlayerScoreInputWrapper teams mode", () => {
       const [roundScore, setRoundScore] = useState<RoundScore>({
         id: 1,
         playersScores: [],
-        teamsScores: [],
+        teamsScores: [
+          { id: 0, teamId: 0, score: 0, boltCount: 0, totalScore: 0 },
+          { id: 1, teamId: 1, score: 0, boltCount: 0, totalScore: 0 },
+        ],
         totalRoundScore: 0,
       });
 

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
@@ -45,7 +45,10 @@ describe("PlayerScoreInputWrapper", () => {
     function Harness() {
       const [roundScore, setRoundScore] = useState<RoundScore>({
         id: 1,
-        playersScores: [],
+        playersScores: [
+          { id: 0, playerId: 0, score: 0, boltCount: 0, totalScore: 0 },
+          { id: 1, playerId: 1, score: 0, boltCount: 0, totalScore: 0 },
+        ],
         teamsScores: [],
         totalRoundScore: 0,
       });

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
@@ -55,6 +55,7 @@ describe("PlayerScoreInputWrapper", () => {
           roundScore={roundScore}
           setRoundScore={setRoundScore}
           roundPlayer={{ id: 0, name: "Alice" }}
+          pointsType="micropoints"
         />
       );
     }

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/roundScoreSelect.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/roundScoreSelect.test.tsx
@@ -24,7 +24,13 @@ function RoundScoreSelectHarness() {
     totalRoundScore: 0,
   });
 
-  return <RoundScoreSelect roundScore={roundScore} setRoundScore={setRoundScore} />;
+  return (
+    <RoundScoreSelect
+      roundScore={roundScore}
+      setRoundScore={setRoundScore}
+      pointsType="micropoints"
+    />
+  );
 }
 
 describe("RoundScoreSelect", () => {

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { type Player, type RoundScore } from "@belot/types";
 
@@ -29,6 +29,10 @@ vi.mock("@/components/game-table/action-buttons/next-round-button/playerScoreInp
 }));
 
 describe("ScoreDialogContent", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders player select when no round player is chosen", () => {
     const setRoundPlayer = vi.fn();
     const setRoundScore = vi.fn();
@@ -41,6 +45,7 @@ describe("ScoreDialogContent", () => {
         setRoundScore={setRoundScore}
         dialogPointsType="micropoints"
         onDialogPointsTypeChange={vi.fn()}
+        isPointsTypeEnabled={false}
       />,
     );
 
@@ -48,7 +53,7 @@ describe("ScoreDialogContent", () => {
   });
 
   it("renders score inputs when round player is chosen", () => {
-    function Harness() {
+    function Harness({ isPointsTypeEnabled }: { isPointsTypeEnabled: boolean }) {
       const [roundPlayer, setRoundPlayer] = useState<Player | null>({ id: 0, name: "Alice" });
       const [roundScore, setRoundScore] = useState<RoundScore>({
         id: 0,
@@ -65,15 +70,33 @@ describe("ScoreDialogContent", () => {
           setRoundScore={setRoundScore}
           dialogPointsType="micropoints"
           onDialogPointsTypeChange={vi.fn()}
+          isPointsTypeEnabled={isPointsTypeEnabled}
         />
       );
     }
 
-    render(<Harness />);
+    render(<Harness isPointsTypeEnabled={true} />);
 
     expect(screen.getByText("Selected player")).toBeTruthy();
     expect(screen.getByText("Points type toggle")).toBeTruthy();
     expect(screen.getByText("Score select")).toBeTruthy();
     expect(screen.getByText("Score inputs")).toBeTruthy();
+  });
+
+  it("hides points type toggle when feature is disabled", () => {
+    render(
+      <ScoreDialogContent
+        roundPlayer={{ id: 0, name: "Alice" }}
+        setRoundPlayer={vi.fn()}
+        roundScore={{ id: 0, playersScores: [], teamsScores: [], totalRoundScore: 0 }}
+        setRoundScore={vi.fn()}
+        dialogPointsType="micropoints"
+        onDialogPointsTypeChange={vi.fn()}
+        isPointsTypeEnabled={false}
+      />,
+    );
+
+    expect(screen.queryByText("Points type toggle")).toBeNull();
+    expect(screen.getByText("Score select")).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
@@ -20,6 +20,10 @@ vi.mock("@/components/game-table/action-buttons/next-round-button/roundPlayerDis
   default: () => <div>Selected player</div>,
 }));
 
+vi.mock("@/components/game-table/action-buttons/next-round-button/dialogPointsTypeToggle", () => ({
+  default: () => <div>Points type toggle</div>,
+}));
+
 vi.mock("@/components/game-table/action-buttons/next-round-button/roundScoreSelect", () => ({
   default: () => <div>Score select</div>,
 }));
@@ -39,6 +43,8 @@ describe("ScoreDialogContent", () => {
         setRoundPlayer={setRoundPlayer}
         roundScore={{ id: 0, playersScores: [], teamsScores: [], totalRoundScore: 0 }}
         setRoundScore={setRoundScore}
+        dialogPointsType="micropoints"
+        onDialogPointsTypeChange={vi.fn()}
       />,
     );
 
@@ -61,6 +67,8 @@ describe("ScoreDialogContent", () => {
           setRoundPlayer={setRoundPlayer}
           roundScore={roundScore}
           setRoundScore={setRoundScore}
+          dialogPointsType="micropoints"
+          onDialogPointsTypeChange={vi.fn()}
         />
       );
     }
@@ -68,6 +76,7 @@ describe("ScoreDialogContent", () => {
     render(<Harness />);
 
     expect(screen.getByText("Selected player")).toBeTruthy();
+    expect(screen.getByText("Points type toggle")).toBeTruthy();
     expect(screen.getByText("Score select")).toBeTruthy();
     expect(screen.getByText("* Helper text")).toBeTruthy();
   });

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
@@ -8,10 +8,6 @@ import { type Player, type RoundScore } from "@belot/types";
 
 import ScoreDialogContent from "@/components/game-table/action-buttons/next-round-button/scoreDialogContent";
 
-vi.mock("@belot/localizations", () => ({
-  useLocalizations: () => ({ nextRoundScoreForPlayerInputHelper: "Helper text" }),
-}));
-
 vi.mock("@/components/game-table/action-buttons/next-round-button/roundPlayerSelect", () => ({
   default: () => <div>Select player</div>,
 }));
@@ -78,6 +74,6 @@ describe("ScoreDialogContent", () => {
     expect(screen.getByText("Selected player")).toBeTruthy();
     expect(screen.getByText("Points type toggle")).toBeTruthy();
     expect(screen.getByText("Score select")).toBeTruthy();
-    expect(screen.getByText("* Helper text")).toBeTruthy();
+    expect(screen.getByText("Score inputs")).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/game-table/pointCells.test.tsx
+++ b/apps/web/tests/components/game-table/pointCells.test.tsx
@@ -7,6 +7,11 @@ import { GameMode } from "@belot/types";
 
 import PointCells from "@/components/game-table/pointCells";
 
+vi.mock("@belot/store", () => ({
+  useGameStore: (selector: (state: { pointsType: string }) => unknown) =>
+    selector({ pointsType: "micropoints" }),
+}));
+
 vi.mock("@belot/utils/src", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@belot/utils/src")>();
   return {
@@ -16,7 +21,6 @@ vi.mock("@belot/utils/src", async (importOriginal) => {
       score.totalScore > 0 ? `+${score.totalScore}` : String(score.totalScore),
     getCurrentScoreColor: (score: { totalScore: number }) =>
       score.totalScore > 0 ? "text-success" : score.totalScore < 0 ? "text-destructive" : "",
-    roundToDecimal: (value: number) => value.toFixed(1),
   };
 });
 
@@ -48,7 +52,7 @@ describe("PointCells", () => {
     expect(screen.getByText("+10")).toBeTruthy();
   });
 
-  it("rounds three-digit total scores in teams mode", () => {
+  it("rounds three-digit micropoint total scores in teams mode", () => {
     render(
       <table>
         <tbody>
@@ -59,7 +63,7 @@ describe("PointCells", () => {
                 id: 0,
                 playersScores: [],
                 teamsScores: [{ id: 0, teamId: 0, score: 100, boltCount: 0, totalScore: 100 }],
-                totalRoundScore: 100,
+                totalRoundScore: 162,
               }}
             />
           </tr>
@@ -67,7 +71,7 @@ describe("PointCells", () => {
       </table>,
     );
 
-    expect(screen.getByText("100.0")).toBeTruthy();
+    expect(screen.getByText("16")).toBeTruthy();
   });
 
   it("uses neutral styling for zero current scores", () => {

--- a/apps/web/tests/components/game-table/pointCells.test.tsx
+++ b/apps/web/tests/components/game-table/pointCells.test.tsx
@@ -7,9 +7,8 @@ import { GameMode } from "@belot/types";
 
 import PointCells from "@/components/game-table/pointCells";
 
-vi.mock("@belot/store", () => ({
-  useGameStore: (selector: (state: { pointsType: string }) => unknown) =>
-    selector({ pointsType: "micropoints" }),
+vi.mock("@belot/hooks", () => ({
+  useEffectivePointsType: () => "micropoints",
 }));
 
 vi.mock("@belot/utils/src", async (importOriginal) => {

--- a/apps/web/tests/pages/settings.test.tsx
+++ b/apps/web/tests/pages/settings.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import SettingsPage from "@/pages/settings";
 
 const setSettings = vi.fn();
 const getSettingsFromLocalStorage = vi.fn();
+
+const mocks = vi.hoisted(() => ({
+  isPointsTypeEnabled: true,
+}));
 
 vi.mock("@belot/hooks", () => ({
   useSettings: ({ getFromStorage, setToStorage }: {
@@ -22,6 +26,7 @@ vi.mock("@belot/hooks", () => ({
       getSettingsFromLocalStorage,
     };
   },
+  useIsPointsTypeEnabled: () => mocks.isPointsTypeEnabled,
 }));
 
 vi.mock("@belot/localizations", () => ({
@@ -51,11 +56,27 @@ vi.mock("@/components/settings/pointsTypeRadioButton", () => ({
 }));
 
 describe("SettingsPage", () => {
+  beforeEach(() => {
+    mocks.isPointsTypeEnabled = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("loads settings and renders page content", () => {
     render(<SettingsPage />);
 
     expect(getSettingsFromLocalStorage).toHaveBeenCalled();
     expect(screen.getByRole("heading", { name: "Settings" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "points" })).toBeTruthy();
+  });
+
+  it("hides points type settings when feature is disabled", () => {
+    mocks.isPointsTypeEnabled = false;
+
+    render(<SettingsPage />);
+
+    expect(screen.queryByRole("button", { name: "points" })).toBeNull();
   });
 });

--- a/packages/constants/src/featureToggles.ts
+++ b/packages/constants/src/featureToggles.ts
@@ -1,6 +1,7 @@
 export const FEATURE_TOGGLES = {
   "settings-screen": false,
   "backend-game-init": false,
+  "points-type": false,
 } as const;
 
 export type FeatureToggleName = keyof typeof FEATURE_TOGGLES;

--- a/packages/hooks/src/featureToggles/FeatureToggleContext.tsx
+++ b/packages/hooks/src/featureToggles/FeatureToggleContext.tsx
@@ -6,6 +6,7 @@ import {
   type FeatureToggleState,
 } from "./featureToggleUtils";
 import type { FeatureToggleStorage } from "./types";
+import { useSyncPointsTypeFeature } from "../usePointsTypeFeature";
 
 export const FeatureToggleContext = createContext<FeatureToggleState>(
   getDefaultFeatureToggleState(),
@@ -14,6 +15,11 @@ export const FeatureToggleContext = createContext<FeatureToggleState>(
 interface FeatureToggleProviderProps extends FeatureToggleStorage {
   children: ReactNode;
 }
+
+const PointsTypeFeatureSync = () => {
+  useSyncPointsTypeFeature();
+  return null;
+};
 
 export const FeatureToggleProvider = ({
   children,
@@ -44,6 +50,9 @@ export const FeatureToggleProvider = ({
   }, [getFromStorage, setToStorage]);
 
   return (
-    <FeatureToggleContext.Provider value={toggles}>{children}</FeatureToggleContext.Provider>
+    <FeatureToggleContext.Provider value={toggles}>
+      <PointsTypeFeatureSync />
+      {children}
+    </FeatureToggleContext.Provider>
   );
 };

--- a/packages/hooks/src/featureToggles/FeatureToggleContext.tsx
+++ b/packages/hooks/src/featureToggles/FeatureToggleContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useEffect, useState, type ReactNode } from "react";
 
 import {
+  areFeatureToggleStatesEqual,
   getDefaultFeatureToggleState,
   syncFeatureTogglesToStorage,
   type FeatureToggleState,
@@ -38,7 +39,9 @@ export const FeatureToggleProvider = ({
       });
 
       if (!isCancelled) {
-        setToggles(syncedToggles);
+        setToggles((current) =>
+          areFeatureToggleStatesEqual(current, syncedToggles) ? current : syncedToggles,
+        );
       }
     };
 

--- a/packages/hooks/src/featureToggles/featureToggleUtils.ts
+++ b/packages/hooks/src/featureToggles/featureToggleUtils.ts
@@ -8,6 +8,8 @@ import type { FeatureToggleStorage } from "./types";
 
 export type FeatureToggleState = Record<FeatureToggleName, boolean>;
 
+const FEATURE_TOGGLE_NAMES = Object.keys(FEATURE_TOGGLES) as FeatureToggleName[];
+
 export const getDefaultFeatureToggleState = (): FeatureToggleState => ({
   ...FEATURE_TOGGLES,
 });
@@ -21,6 +23,63 @@ export const logUnknownFeatureToggle = (name: string): void => {
   );
 };
 
+export const serializeFeatureToggleState = (state: FeatureToggleState): string =>
+  JSON.stringify(
+    FEATURE_TOGGLE_NAMES.reduce<FeatureToggleState>((serializedState, name) => {
+      serializedState[name] = state[name];
+      return serializedState;
+    }, {} as FeatureToggleState),
+  );
+
+export const parseStoredFeatureToggles = (
+  storedValue: string | null,
+): Partial<FeatureToggleState> | null => {
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(storedValue);
+
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const storedRecord = parsed as Record<string, unknown>;
+    const parsedToggles: Partial<FeatureToggleState> = {};
+
+    FEATURE_TOGGLE_NAMES.forEach((name) => {
+      const value = storedRecord[name];
+
+      if (typeof value === "boolean") {
+        parsedToggles[name] = value;
+      }
+    });
+
+    return parsedToggles;
+  } catch {
+    return null;
+  }
+};
+
+export const needsFeatureToggleStorageSync = (
+  storedValue: string | null,
+  centralizedState: FeatureToggleState,
+): boolean => {
+  const storedToggles = parseStoredFeatureToggles(storedValue);
+
+  if (!storedToggles) {
+    return true;
+  }
+
+  return FEATURE_TOGGLE_NAMES.some((name) => storedToggles[name] !== centralizedState[name]);
+};
+
+export const areFeatureToggleStatesEqual = (
+  left: FeatureToggleState,
+  right: FeatureToggleState,
+): boolean => FEATURE_TOGGLE_NAMES.every((name) => left[name] === right[name]);
+
 export const syncFeatureTogglesToStorage = async ({
   getFromStorage,
   setToStorage,
@@ -28,10 +87,12 @@ export const syncFeatureTogglesToStorage = async ({
   const centralizedState = getDefaultFeatureToggleState();
   const storedValue = await getFromStorage(StorageKeys.featureToggles);
 
-  if (storedValue === JSON.stringify(centralizedState)) {
-    return centralizedState;
+  if (needsFeatureToggleStorageSync(storedValue, centralizedState)) {
+    await setToStorage(
+      StorageKeys.featureToggles,
+      serializeFeatureToggleState(centralizedState),
+    );
   }
 
-  await setToStorage(StorageKeys.featureToggles, JSON.stringify(centralizedState));
   return centralizedState;
 };

--- a/packages/hooks/src/featureToggles/useFeatureToggle.ts
+++ b/packages/hooks/src/featureToggles/useFeatureToggle.ts
@@ -11,5 +11,5 @@ export const useFeatureToggle = (name: string): boolean => {
     return false;
   }
 
-  return toggles[name];
+  return toggles[name] ?? false;
 };

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -17,4 +17,5 @@ export * from "./useHandleNextRound";
 export * from "./useHandleSkipRound";
 export * from "./useStartingScreenActions";
 export * from "./useSettings";
+export * from "./usePointsTypeFeature";
 export * from "./featureToggles";

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -19,4 +19,5 @@ export * from "./useHandleSkipRound";
 export * from "./useStartingScreenActions";
 export * from "./useSettings";
 export * from "./usePointsTypeFeature";
+export * from "./usePointsTypeSelection";
 export * from "./featureToggles";

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -14,6 +14,7 @@ export * from "./useTimeTracker";
 export * from "./useHandleConfirmationDialog";
 export * from "./useGetTableHeaderDealerBackground";
 export * from "./useHandleNextRound";
+export * from "./useSyncPlayerScoreInput";
 export * from "./useHandleSkipRound";
 export * from "./useStartingScreenActions";
 export * from "./useSettings";

--- a/packages/hooks/src/useHandleNextRound.ts
+++ b/packages/hooks/src/useHandleNextRound.ts
@@ -1,11 +1,12 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
 
-import { DEFAULT_ROUND_POINTS, StorageKeys } from "@belot/constants";
+import { StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore, Team } from "@belot/types";
 import {
   calculateRoundScore,
   checkForGameWinner,
+  getDefaultRoundPoints,
   prepareEmptyRoundScoreRow,
   setNextDealer,
 } from "@belot/utils";
@@ -15,17 +16,20 @@ interface UseHandleNextRoundProps {
   setToLocalStorage: (key: StorageKeys, value: string) => void;
 }
 
-const defaultRoundScoreState: RoundScore = {
+const createDefaultRoundScoreState = (pointsType: string): RoundScore => ({
   id: 0,
   playersScores: [],
   teamsScores: [],
-  totalRoundScore: DEFAULT_ROUND_POINTS,
+  totalRoundScore: getDefaultRoundPoints(pointsType),
   roundPlayer: null,
-};
+});
 
 export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNextRoundProps) => {
+  const pointsType = useGameStore((state) => state.pointsType);
   const [roundPlayer, setRoundPlayer] = useState<Player | null>(null);
-  const [roundScore, setRoundScore] = useState<RoundScore>(defaultRoundScoreState);
+  const [roundScore, setRoundScore] = useState<RoundScore>(
+    createDefaultRoundScoreState(pointsType),
+  );
   const [gameOverflowCount, setGameOverflowCount] = useState(0);
 
   const players = useGameStore((state) => state.players);
@@ -42,11 +46,11 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
   }, []);
 
   const handleNextRound = useCallback(() => {
-    const calculatedRoundScore = calculateRoundScore(roundScore, roundPlayer, gameMode);
+    const calculatedRoundScore = calculateRoundScore(roundScore, roundPlayer, gameMode, pointsType);
     updateRoundScore(calculatedRoundScore);
 
     setRoundPlayer(null);
-    setRoundScore(defaultRoundScoreState);
+    setRoundScore(createDefaultRoundScoreState(pointsType));
 
     setWinner(
       checkForGameWinner(
@@ -56,6 +60,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
         calculatedRoundScore,
         gameOverflowCount,
         setGameOverflowCount,
+        pointsType,
       ),
     );
 
@@ -76,6 +81,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
       players,
       teams,
       mode: gameMode,
+      pointsType,
       roundsScores: updatedRoundsScores,
     });
 
@@ -96,6 +102,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
     gameMode,
     gameOverflowCount,
     players,
+    pointsType,
     roundPlayer,
     roundScore,
     roundsScores,

--- a/packages/hooks/src/useHandleNextRound.ts
+++ b/packages/hooks/src/useHandleNextRound.ts
@@ -6,6 +6,7 @@ import type { Player, RoundScore, Team } from "@belot/types";
 import {
   calculateRoundScore,
   checkForGameWinner,
+  convertRoundScoreForPointsType,
   getDefaultRoundPoints,
   prepareEmptyRoundScoreRow,
   setNextDealer,
@@ -30,6 +31,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
   const [roundScore, setRoundScore] = useState<RoundScore>(
     createDefaultRoundScoreState(pointsType),
   );
+  const [dialogPointsType, setDialogPointsType] = useState(pointsType);
   const [gameOverflowCount, setGameOverflowCount] = useState(0);
 
   const players = useGameStore((state) => state.players);
@@ -43,14 +45,29 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
 
   const handleCancel = useCallback(() => {
     setRoundPlayer(null);
-  }, []);
+    setDialogPointsType(pointsType);
+  }, [pointsType]);
+
+  const handleDialogPointsTypeChange = useCallback(
+    (newPointsType: string) => {
+      setRoundScore((prev) => convertRoundScoreForPointsType(prev, dialogPointsType, newPointsType));
+      setDialogPointsType(newPointsType);
+    },
+    [dialogPointsType],
+  );
 
   const handleNextRound = useCallback(() => {
-    const calculatedRoundScore = calculateRoundScore(roundScore, roundPlayer, gameMode, pointsType);
+    const calculatedRoundScore = calculateRoundScore(
+      roundScore,
+      roundPlayer,
+      gameMode,
+      dialogPointsType,
+    );
     updateRoundScore(calculatedRoundScore);
 
     setRoundPlayer(null);
     setRoundScore(createDefaultRoundScoreState(pointsType));
+    setDialogPointsType(pointsType);
 
     setWinner(
       checkForGameWinner(
@@ -60,7 +77,6 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
         calculatedRoundScore,
         gameOverflowCount,
         setGameOverflowCount,
-        pointsType,
       ),
     );
 
@@ -99,6 +115,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
     setToLocalStorage(StorageKeys.dealer, JSON.stringify(nextDealer));
   }, [
     dealer,
+    dialogPointsType,
     gameMode,
     gameOverflowCount,
     players,
@@ -114,22 +131,27 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
 
   const handleDialogOpen = useCallback(
     (showDialog: () => void) => {
+      setDialogPointsType(pointsType);
+
       const lastRoundScores = roundsScores.at(-1);
       if (lastRoundScores) {
         setRoundScore(lastRoundScores);
       }
+
       showDialog();
     },
-    [roundsScores],
+    [pointsType, roundsScores],
   );
 
   return {
     handleNextRound,
     handleCancel,
     handleDialogOpen,
+    onDialogPointsTypeChange: handleDialogPointsTypeChange,
     roundPlayer,
     setRoundPlayer,
     roundScore,
     setRoundScore,
+    dialogPointsType,
   };
 };

--- a/packages/hooks/src/useHandleNextRound.ts
+++ b/packages/hooks/src/useHandleNextRound.ts
@@ -4,11 +4,13 @@ import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore, Team } from "@belot/types";
 import {
+  applyDefaultTotalRoundScore,
   calculateRoundScore,
   checkForGameWinner,
   convertRoundScoreForPointsType,
   getDefaultRoundPoints,
   prepareEmptyRoundScoreRow,
+  repairRoundScoreScores,
   setNextDealer,
 } from "@belot/utils";
 
@@ -145,12 +147,23 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
 
       const lastRoundScores = roundsScores.at(-1);
       if (lastRoundScores) {
-        setRoundScore(lastRoundScores);
+        setRoundScore(
+          applyDefaultTotalRoundScore(
+            repairRoundScoreScores(lastRoundScores, {
+              players,
+              teams,
+              mode: gameMode,
+              pointsType,
+              roundsScores,
+            }),
+            pointsType,
+          ),
+        );
       }
 
       showDialog();
     },
-    [pointsType, roundsScores],
+    [gameMode, players, pointsType, roundsScores, teams],
   );
 
   return {

--- a/packages/hooks/src/useHandleNextRound.ts
+++ b/packages/hooks/src/useHandleNextRound.ts
@@ -1,6 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
 
-import { StorageKeys } from "@belot/constants";
+import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore, Team } from "@belot/types";
 import {
@@ -11,6 +11,8 @@ import {
   prepareEmptyRoundScoreRow,
   setNextDealer,
 } from "@belot/utils";
+
+import { useIsPointsTypeEnabled } from "./usePointsTypeFeature";
 
 interface UseHandleNextRoundProps {
   setWinner: Dispatch<SetStateAction<Player | Team | null>>;
@@ -26,7 +28,9 @@ const createDefaultRoundScoreState = (pointsType: string): RoundScore => ({
 });
 
 export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNextRoundProps) => {
-  const pointsType = useGameStore((state) => state.pointsType);
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
+  const storePointsType = useGameStore((state) => state.pointsType);
+  const pointsType = isPointsTypeEnabled ? storePointsType : POINTS_TYPE[0].id;
   const [roundPlayer, setRoundPlayer] = useState<Player | null>(null);
   const [roundScore, setRoundScore] = useState<RoundScore>(
     createDefaultRoundScoreState(pointsType),
@@ -50,18 +54,24 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
 
   const handleDialogPointsTypeChange = useCallback(
     (newPointsType: string) => {
+      if (!isPointsTypeEnabled) {
+        return;
+      }
+
       setRoundScore((prev) => convertRoundScoreForPointsType(prev, dialogPointsType, newPointsType));
       setDialogPointsType(newPointsType);
     },
-    [dialogPointsType],
+    [dialogPointsType, isPointsTypeEnabled],
   );
+
+  const activePointsType = isPointsTypeEnabled ? dialogPointsType : pointsType;
 
   const handleNextRound = useCallback(() => {
     const calculatedRoundScore = calculateRoundScore(
       roundScore,
       roundPlayer,
       gameMode,
-      dialogPointsType,
+      activePointsType,
     );
     updateRoundScore(calculatedRoundScore);
 
@@ -114,8 +124,8 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
 
     setToLocalStorage(StorageKeys.dealer, JSON.stringify(nextDealer));
   }, [
+    activePointsType,
     dealer,
-    dialogPointsType,
     gameMode,
     gameOverflowCount,
     players,
@@ -152,6 +162,7 @@ export const useHandleNextRound = ({ setWinner, setToLocalStorage }: UseHandleNe
     setRoundPlayer,
     roundScore,
     setRoundScore,
-    dialogPointsType,
+    dialogPointsType: activePointsType,
+    isPointsTypeEnabled,
   };
 };

--- a/packages/hooks/src/useHandleSkipRound.ts
+++ b/packages/hooks/src/useHandleSkipRound.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
-import { prepareEmptyRoundScoreRow, roundByLastDigit, setNextDealer } from "@belot/utils";
+import { normalizeSkippedRoundScore, prepareEmptyRoundScoreRow, setNextDealer } from "@belot/utils";
 
 interface UseHandleSkipRoundProps {
   setItemsToStorage: (items: Partial<Record<StorageKeys, string>>) => Promise<void> | void;
@@ -12,6 +12,7 @@ export const useHandleSkipRound = ({ setItemsToStorage }: UseHandleSkipRoundProp
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
   const mode = useGameStore((state) => state.mode);
+  const pointsType = useGameStore((state) => state.pointsType);
   const roundsScores = useGameStore((state) =>
     Array.isArray(state.roundsScores) ? state.roundsScores : [],
   );
@@ -32,13 +33,17 @@ export const useHandleSkipRound = ({ setItemsToStorage }: UseHandleSkipRoundProp
 
     updatedRoundsScores[lastIndex] = {
       ...lastRoundScore,
-      totalRoundScore: roundByLastDigit(lastRoundScore.totalRoundScore),
+      totalRoundScore: normalizeSkippedRoundScore(
+        lastRoundScore.totalRoundScore,
+        pointsType,
+      ),
     };
 
     const newEmptyRow = prepareEmptyRoundScoreRow({
       players,
       teams,
       mode,
+      pointsType,
       roundsScores: updatedRoundsScores,
     });
 
@@ -58,5 +63,5 @@ export const useHandleSkipRound = ({ setItemsToStorage }: UseHandleSkipRoundProp
     }
 
     await setItemsToStorage(storageItems);
-  }, [dealer, mode, players, roundsScores, setItemsToStorage, skipRound, teams]);
+  }, [dealer, mode, players, pointsType, roundsScores, setItemsToStorage, skipRound, teams]);
 };

--- a/packages/hooks/src/useHandleSkipRound.ts
+++ b/packages/hooks/src/useHandleSkipRound.ts
@@ -4,6 +4,8 @@ import { StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import { normalizeSkippedRoundScore, prepareEmptyRoundScoreRow, setNextDealer } from "@belot/utils";
 
+import { useEffectivePointsType } from "./usePointsTypeFeature";
+
 interface UseHandleSkipRoundProps {
   setItemsToStorage: (items: Partial<Record<StorageKeys, string>>) => Promise<void> | void;
 }
@@ -12,7 +14,7 @@ export const useHandleSkipRound = ({ setItemsToStorage }: UseHandleSkipRoundProp
   const players = useGameStore((state) => state.players);
   const teams = useGameStore((state) => state.teams);
   const mode = useGameStore((state) => state.mode);
-  const pointsType = useGameStore((state) => state.pointsType);
+  const pointsType = useEffectivePointsType();
   const roundsScores = useGameStore((state) =>
     Array.isArray(state.roundsScores) ? state.roundsScores : [],
   );

--- a/packages/hooks/src/useLoadGameData.ts
+++ b/packages/hooks/src/useLoadGameData.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore } from "@belot/types";
+import type { Settings } from "./useSettings";
 
 interface UseLoadGameDataBaseProps {
   getFromStorage: (key: StorageKeys) => Promise<string | null> | string | null;
@@ -44,6 +45,7 @@ export function useLoadGameData({
   const setPlayers = useGameStore((state) => state.setPlayers);
   const setDealer = useGameStore((state) => state.setDealer);
   const setRoundsScores = useGameStore((state) => state.setRoundsScores);
+  const setPointsType = useGameStore((state) => state.setPointsType);
 
   useEffect(() => {
     const shouldFetchStorage =
@@ -55,6 +57,12 @@ export function useLoadGameData({
         const storagePlayers = await getFromStorage(StorageKeys.players);
         const storageDealer = await getFromStorage(StorageKeys.dealer);
         const storageRoundsScores = await getFromStorage(StorageKeys.roundsScores);
+        const storageSettings = await getFromStorage(StorageKeys.settings);
+
+        if (storageSettings) {
+          const parsedSettings = JSON.parse(storageSettings) as Settings;
+          setPointsType(parsedSettings.pointsType);
+        }
 
         if (storagePlayers && storageDealer && storageRoundsScores) {
           const parsedPlayers = JSON.parse(storagePlayers) as Player[];
@@ -86,6 +94,7 @@ export function useLoadGameData({
     roundsScores?.length,
     setDealer,
     setPlayers,
+    setPointsType,
     setRoundsScores,
     shouldSetData,
   ]);

--- a/packages/hooks/src/useLoadGameData.ts
+++ b/packages/hooks/src/useLoadGameData.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react";
 
 import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
-import type { Player, RoundScore } from "@belot/types";
+import { GameMode, type Player, type RoundScore } from "@belot/types";
+import { applyDefaultTotalRoundScore, repairRoundScoreScores } from "@belot/utils";
 import type { Settings } from "./useSettings";
 import { useIsPointsTypeEnabled } from "./usePointsTypeFeature";
 
@@ -48,6 +49,11 @@ export function useLoadGameData({
   const setRoundsScores = useGameStore((state) => state.setRoundsScores);
   const setPointsType = useGameStore((state) => state.setPointsType);
   const isPointsTypeEnabled = useIsPointsTypeEnabled();
+  const getFromStorageRef = useRef(getFromStorage);
+
+  useEffect(() => {
+    getFromStorageRef.current = getFromStorage;
+  }, [getFromStorage]);
 
   useEffect(() => {
     const shouldFetchStorage =
@@ -56,10 +62,12 @@ export function useLoadGameData({
 
     if (shouldFetchStorage) {
       const fetchData = async () => {
-        const storagePlayers = await getFromStorage(StorageKeys.players);
-        const storageDealer = await getFromStorage(StorageKeys.dealer);
-        const storageRoundsScores = await getFromStorage(StorageKeys.roundsScores);
-        const storageSettings = await getFromStorage(StorageKeys.settings);
+        const storagePlayers = await getFromStorageRef.current(StorageKeys.players);
+        const storageDealer = await getFromStorageRef.current(StorageKeys.dealer);
+        const storageRoundsScores = await getFromStorageRef.current(StorageKeys.roundsScores);
+        const storageSettings = await getFromStorageRef.current(StorageKeys.settings);
+
+        let parsedPointsType = POINTS_TYPE[0].id;
 
         if (storageSettings && isPointsTypeEnabled) {
           try {
@@ -67,7 +75,11 @@ export function useLoadGameData({
             const isValidPointsType = POINTS_TYPE.some((type) => type.id === parsedSettings.pointsType);
 
             if (isValidPointsType) {
-              setPointsType(parsedSettings.pointsType);
+              parsedPointsType = parsedSettings.pointsType;
+
+              if (parsedPointsType !== useGameStore.getState().pointsType) {
+                setPointsType(parsedPointsType);
+              }
             }
           } catch {
             // Ignore invalid settings payloads and keep the default points type.
@@ -77,7 +89,26 @@ export function useLoadGameData({
         if (storagePlayers && storageDealer && storageRoundsScores) {
           const parsedPlayers = JSON.parse(storagePlayers) as Player[];
           const parsedDealer = JSON.parse(storageDealer) as Player;
-          const parsedRoundsScores = JSON.parse(storageRoundsScores) as RoundScore[];
+          let parsedRoundsScores = JSON.parse(storageRoundsScores) as RoundScore[];
+
+          if (parsedRoundsScores.length > 0) {
+            const lastRoundIndex = parsedRoundsScores.length - 1;
+            const gameMode =
+              parsedPlayers.length === 4 ? GameMode.teams : GameMode.classic;
+
+            parsedRoundsScores = [
+              ...parsedRoundsScores.slice(0, lastRoundIndex),
+              applyDefaultTotalRoundScore(
+                repairRoundScoreScores(parsedRoundsScores[lastRoundIndex], {
+                  players: parsedPlayers,
+                  mode: gameMode,
+                  pointsType: parsedPointsType,
+                  roundsScores: parsedRoundsScores,
+                }),
+                parsedPointsType,
+              ),
+            ];
+          }
 
           if (shouldSetData) {
             setPlayers(parsedPlayers);
@@ -99,7 +130,6 @@ export function useLoadGameData({
     }
   }, [
     dealer,
-    getFromStorage,
     isPointsTypeEnabled,
     players?.length,
     roundsScores?.length,

--- a/packages/hooks/src/useLoadGameData.ts
+++ b/packages/hooks/src/useLoadGameData.ts
@@ -4,6 +4,7 @@ import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore } from "@belot/types";
 import type { Settings } from "./useSettings";
+import { useIsPointsTypeEnabled } from "./usePointsTypeFeature";
 
 interface UseLoadGameDataBaseProps {
   getFromStorage: (key: StorageKeys) => Promise<string | null> | string | null;
@@ -46,6 +47,7 @@ export function useLoadGameData({
   const setDealer = useGameStore((state) => state.setDealer);
   const setRoundsScores = useGameStore((state) => state.setRoundsScores);
   const setPointsType = useGameStore((state) => state.setPointsType);
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
 
   useEffect(() => {
     const shouldFetchStorage =
@@ -59,7 +61,7 @@ export function useLoadGameData({
         const storageRoundsScores = await getFromStorage(StorageKeys.roundsScores);
         const storageSettings = await getFromStorage(StorageKeys.settings);
 
-        if (storageSettings) {
+        if (storageSettings && isPointsTypeEnabled) {
           try {
             const parsedSettings = JSON.parse(storageSettings) as Settings;
             const isValidPointsType = POINTS_TYPE.some((type) => type.id === parsedSettings.pointsType);
@@ -98,6 +100,7 @@ export function useLoadGameData({
   }, [
     dealer,
     getFromStorage,
+    isPointsTypeEnabled,
     players?.length,
     roundsScores?.length,
     setDealer,

--- a/packages/hooks/src/useLoadGameData.ts
+++ b/packages/hooks/src/useLoadGameData.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { StorageKeys } from "@belot/constants";
+import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import type { Player, RoundScore } from "@belot/types";
 import type { Settings } from "./useSettings";
@@ -60,8 +60,16 @@ export function useLoadGameData({
         const storageSettings = await getFromStorage(StorageKeys.settings);
 
         if (storageSettings) {
-          const parsedSettings = JSON.parse(storageSettings) as Settings;
-          setPointsType(parsedSettings.pointsType);
+          try {
+            const parsedSettings = JSON.parse(storageSettings) as Settings;
+            const isValidPointsType = POINTS_TYPE.some((type) => type.id === parsedSettings.pointsType);
+
+            if (isValidPointsType) {
+              setPointsType(parsedSettings.pointsType);
+            }
+          } catch {
+            // Ignore invalid settings payloads and keep the default points type.
+          }
         }
 
         if (storagePlayers && storageDealer && storageRoundsScores) {

--- a/packages/hooks/src/useLoadGameData.ts
+++ b/packages/hooks/src/useLoadGameData.ts
@@ -1,14 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 
-import { POINTS_TYPE, StorageKeys } from "@belot/constants";
+import { StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import { GameMode, type Player, type RoundScore } from "@belot/types";
-import { applyDefaultTotalRoundScore, repairRoundScoreScores } from "@belot/utils";
+import { applyDefaultTotalRoundScore, getDefaultPointsType, parseStoredPointsType, repairRoundScoreScores } from "@belot/utils";
 import type { Settings } from "./useSettings";
 import { useIsPointsTypeEnabled } from "./usePointsTypeFeature";
 
 interface UseLoadGameDataBaseProps {
   getFromStorage: (key: StorageKeys) => Promise<string | null> | string | null;
+  setToStorage?: (key: StorageKeys, value: string) => Promise<void> | void;
 }
 
 interface UseLoadGameDataSetProps extends UseLoadGameDataBaseProps {
@@ -32,6 +33,7 @@ export function useLoadGameData(props: UseLoadGameDataSetProps): null;
 
 export function useLoadGameData({
   getFromStorage,
+  setToStorage,
   shouldSetData = true,
 }: UseLoadGameDataSetProps | (UseLoadGameDataReadProps & { shouldSetData: false })) {
   const hasFetchedData = useRef(false);
@@ -50,10 +52,15 @@ export function useLoadGameData({
   const setPointsType = useGameStore((state) => state.setPointsType);
   const isPointsTypeEnabled = useIsPointsTypeEnabled();
   const getFromStorageRef = useRef(getFromStorage);
+  const setToStorageRef = useRef(setToStorage);
 
   useEffect(() => {
     getFromStorageRef.current = getFromStorage;
   }, [getFromStorage]);
+
+  useEffect(() => {
+    setToStorageRef.current = setToStorage;
+  }, [setToStorage]);
 
   useEffect(() => {
     const shouldFetchStorage =
@@ -67,22 +74,24 @@ export function useLoadGameData({
         const storageRoundsScores = await getFromStorageRef.current(StorageKeys.roundsScores);
         const storageSettings = await getFromStorageRef.current(StorageKeys.settings);
 
-        let parsedPointsType = POINTS_TYPE[0].id;
+        let parsedPointsType = getDefaultPointsType();
 
         if (storageSettings && isPointsTypeEnabled) {
-          try {
-            const parsedSettings = JSON.parse(storageSettings) as Settings;
-            const isValidPointsType = POINTS_TYPE.some((type) => type.id === parsedSettings.pointsType);
+          const storedPointsType = parseStoredPointsType(storageSettings);
 
-            if (isValidPointsType) {
-              parsedPointsType = parsedSettings.pointsType;
+          if (storedPointsType) {
+            parsedPointsType = storedPointsType;
 
-              if (parsedPointsType !== useGameStore.getState().pointsType) {
-                setPointsType(parsedPointsType);
-              }
+            if (parsedPointsType !== useGameStore.getState().pointsType) {
+              setPointsType(parsedPointsType);
             }
-          } catch {
-            // Ignore invalid settings payloads and keep the default points type.
+          } else {
+            const defaultSettings: Settings = { pointsType: getDefaultPointsType() };
+
+            await setToStorageRef.current?.(
+              StorageKeys.settings,
+              JSON.stringify(defaultSettings),
+            );
           }
         }
 

--- a/packages/hooks/src/usePlayersSubmit.ts
+++ b/packages/hooks/src/usePlayersSubmit.ts
@@ -18,6 +18,7 @@ interface UsePlayersSubmitProps {
   navigateFunction: () => void;
   setItemsToStorage: (items: Partial<Record<StorageKeys, string>>) => Promise<void> | void;
   getApiBaseUrl: () => string;
+  getFromStorage: (key: StorageKeys) => Promise<string | null> | string | null;
   handleCatchError: (error: unknown) => void;
 }
 
@@ -25,6 +26,7 @@ export function usePlayersSubmit({
   navigateFunction,
   setItemsToStorage,
   getApiBaseUrl,
+  getFromStorage,
   handleCatchError,
 }: UsePlayersSubmitProps) {
   const { setValidations } = usePlayersSelectionContext();
@@ -36,6 +38,7 @@ export function usePlayersSubmit({
   const mode = useGameStore((state) => state.mode);
   const setEmptyRoundScore = useGameStore((state) => state.setEmptyRoundScore);
   const setGameId = useGameStore((state) => state.setGameId);
+  const setPointsType = useGameStore((state) => state.setPointsType);
   const isBackendGameInitEnabled = useFeatureToggle("backend-game-init");
 
   const handleOpenDialog = useCallback(
@@ -64,10 +67,20 @@ export function usePlayersSubmit({
 
     setEmptyRoundScore();
 
+    const storageSettings = await getFromStorage(StorageKeys.settings);
+    const pointsType = storageSettings
+      ? (JSON.parse(storageSettings) as { pointsType: string }).pointsType
+      : undefined;
+
+    if (pointsType) {
+      setPointsType(pointsType);
+    }
+
     const emptyRoundScore: RoundScore = prepareEmptyRoundScoreRow({
       dealer,
       mode,
       players,
+      pointsType,
     });
 
     await setItemsToStorage({
@@ -101,6 +114,7 @@ export function usePlayersSubmit({
     );
   }, [
     dealer,
+    getFromStorage,
     handleCatchError,
     initGame,
     isBackendGameInitEnabled,
@@ -110,6 +124,7 @@ export function usePlayersSubmit({
     setEmptyRoundScore,
     setGameId,
     setItemsToStorage,
+    setPointsType,
     setValidations,
   ]);
 

--- a/packages/hooks/src/usePlayersSubmit.ts
+++ b/packages/hooks/src/usePlayersSubmit.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
 import { useGameInit } from "@belot/api-client";
-import { StorageKeys } from "@belot/constants";
+import { POINTS_TYPE, StorageKeys } from "@belot/constants";
 import { useGameStore } from "@belot/store";
 import { type RoundScore } from "@belot/types";
 import {
@@ -13,6 +13,7 @@ import {
 
 import { usePlayersSelectionContext } from "./usePlayersSelectionContext";
 import { useFeatureToggle } from "./featureToggles/useFeatureToggle";
+import { useIsPointsTypeEnabled } from "./usePointsTypeFeature";
 
 interface UsePlayersSubmitProps {
   navigateFunction: () => void;
@@ -40,6 +41,7 @@ export function usePlayersSubmit({
   const setGameId = useGameStore((state) => state.setGameId);
   const setPointsType = useGameStore((state) => state.setPointsType);
   const isBackendGameInitEnabled = useFeatureToggle("backend-game-init");
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
 
   const handleOpenDialog = useCallback(
     (showDialog: () => void) => {
@@ -68,11 +70,12 @@ export function usePlayersSubmit({
     setEmptyRoundScore();
 
     const storageSettings = await getFromStorage(StorageKeys.settings);
-    const pointsType = storageSettings
+    const storedPointsType = storageSettings
       ? (JSON.parse(storageSettings) as { pointsType: string }).pointsType
       : undefined;
+    const pointsType = isPointsTypeEnabled ? storedPointsType : POINTS_TYPE[0].id;
 
-    if (pointsType) {
+    if (isPointsTypeEnabled && pointsType) {
       setPointsType(pointsType);
     }
 
@@ -118,6 +121,7 @@ export function usePlayersSubmit({
     handleCatchError,
     initGame,
     isBackendGameInitEnabled,
+    isPointsTypeEnabled,
     mode,
     navigateFunction,
     players,

--- a/packages/hooks/src/usePlayersSubmit.ts
+++ b/packages/hooks/src/usePlayersSubmit.ts
@@ -37,7 +37,7 @@ export function usePlayersSubmit({
   const players = useGameStore((state) => state.players);
   const dealer = useGameStore((state) => state.dealer);
   const mode = useGameStore((state) => state.mode);
-  const setEmptyRoundScore = useGameStore((state) => state.setEmptyRoundScore);
+  const setRoundsScores = useGameStore((state) => state.setRoundsScores);
   const setGameId = useGameStore((state) => state.setGameId);
   const setPointsType = useGameStore((state) => state.setPointsType);
   const isBackendGameInitEnabled = useFeatureToggle("backend-game-init");
@@ -67,24 +67,26 @@ export function usePlayersSubmit({
       return;
     }
 
-    setEmptyRoundScore();
-
     const storageSettings = await getFromStorage(StorageKeys.settings);
     const storedPointsType = storageSettings
       ? (JSON.parse(storageSettings) as { pointsType: string }).pointsType
       : undefined;
-    const pointsType = isPointsTypeEnabled ? storedPointsType : POINTS_TYPE[0].id;
+    const pointsType = isPointsTypeEnabled
+      ? storedPointsType ?? POINTS_TYPE[0].id
+      : POINTS_TYPE[0].id;
 
-    if (isPointsTypeEnabled && pointsType) {
-      setPointsType(pointsType);
-    }
+    setPointsType(pointsType);
 
     const emptyRoundScore: RoundScore = prepareEmptyRoundScoreRow({
       dealer,
       mode,
       players,
+      teams: prepareTeams(players, mode),
       pointsType,
+      roundsScores: [],
     });
+
+    setRoundsScores([emptyRoundScore]);
 
     await setItemsToStorage({
       [StorageKeys.timerStartTime]: "",
@@ -125,7 +127,7 @@ export function usePlayersSubmit({
     mode,
     navigateFunction,
     players,
-    setEmptyRoundScore,
+    setRoundsScores,
     setGameId,
     setItemsToStorage,
     setPointsType,

--- a/packages/hooks/src/usePointsTypeFeature.ts
+++ b/packages/hooks/src/usePointsTypeFeature.ts
@@ -16,11 +16,12 @@ export const useEffectivePointsType = () => {
 
 export const useSyncPointsTypeFeature = () => {
   const isPointsTypeEnabled = useIsPointsTypeEnabled();
+  const pointsType = useGameStore((state) => state.pointsType);
   const setPointsType = useGameStore((state) => state.setPointsType);
 
   useEffect(() => {
-    if (!isPointsTypeEnabled) {
+    if (!isPointsTypeEnabled && pointsType !== POINTS_TYPE[0].id) {
       setPointsType(POINTS_TYPE[0].id);
     }
-  }, [isPointsTypeEnabled, setPointsType]);
+  }, [isPointsTypeEnabled, pointsType, setPointsType]);
 };

--- a/packages/hooks/src/usePointsTypeFeature.ts
+++ b/packages/hooks/src/usePointsTypeFeature.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+import { POINTS_TYPE } from "@belot/constants";
+import { useGameStore } from "@belot/store";
+
+import { useFeatureToggle } from "./featureToggles/useFeatureToggle";
+
+export const useIsPointsTypeEnabled = () => useFeatureToggle("points-type");
+
+export const useEffectivePointsType = () => {
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
+  const storePointsType = useGameStore((state) => state.pointsType);
+
+  return isPointsTypeEnabled ? storePointsType : POINTS_TYPE[0].id;
+};
+
+export const useSyncPointsTypeFeature = () => {
+  const isPointsTypeEnabled = useIsPointsTypeEnabled();
+  const setPointsType = useGameStore((state) => state.setPointsType);
+
+  useEffect(() => {
+    if (!isPointsTypeEnabled) {
+      setPointsType(POINTS_TYPE[0].id);
+    }
+  }, [isPointsTypeEnabled, setPointsType]);
+};

--- a/packages/hooks/src/usePointsTypeSelection.ts
+++ b/packages/hooks/src/usePointsTypeSelection.ts
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+
+import { formatLocalizationKey, useLocalizations } from "@belot/localizations";
+
+const POINTS_TYPE_OPTION_KEYS = [
+  { key: "settings.points.type.micropoints" },
+  { key: "settings.points.type.points" },
+] as const;
+
+const SETTINGS_LABEL_KEYS = [
+  { key: "settings.points.type" },
+  { key: "settings.points.type.hint" },
+] as const;
+
+interface UsePointsTypeSelectionParams {
+  value: string;
+  onChange: (pointsType: string) => void | Promise<void>;
+  includeSettingsLabels?: boolean;
+}
+
+export const usePointsTypeSelection = ({
+  value,
+  onChange,
+  includeSettingsLabels = false,
+}: UsePointsTypeSelectionParams) => {
+  const messages = useLocalizations(
+    includeSettingsLabels ? [...SETTINGS_LABEL_KEYS, ...POINTS_TYPE_OPTION_KEYS] : [...POINTS_TYPE_OPTION_KEYS],
+  );
+
+  const handleChange = useCallback(
+    (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+
+      void onChange(newValue);
+    },
+    [onChange, value],
+  );
+
+  const getOptionLabel = useCallback(
+    (localizationKey: string) => messages[formatLocalizationKey(localizationKey)],
+    [messages],
+  );
+
+  return {
+    messages,
+    handleChange,
+    getOptionLabel,
+  };
+};

--- a/packages/hooks/src/useSettings.ts
+++ b/packages/hooks/src/useSettings.ts
@@ -43,12 +43,25 @@ export const useSettings = ({ getFromStorage, setToStorage }: UseSettings) => {
     }
 
     const parsedSettings = JSON.parse(settingsFromStorage) as Settings;
+
+    if (settingsRef.current.pointsType === parsedSettings.pointsType) {
+      return;
+    }
+
     settingsRef.current = parsedSettings;
     setSettings(parsedSettings);
   }, [getFromStorage]);
 
   const setSettingsToLocalStorage = useCallback(
     async (newSettings: Partial<Settings>) => {
+      const hasChanges = Object.entries(newSettings).some(
+        ([key, value]) => settingsRef.current[key as keyof Settings] !== value,
+      );
+
+      if (!hasChanges) {
+        return;
+      }
+
       storageRequestIdRef.current += 1;
       const updatedSettings = {
         ...settingsRef.current,

--- a/packages/hooks/src/useSyncPlayerScoreInput.ts
+++ b/packages/hooks/src/useSyncPlayerScoreInput.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+
+interface UseSyncPlayerScoreInputParams {
+  opponentId: number;
+  totalRoundScore: number;
+  targetScore: number;
+  onScoreChange: (value: number) => void;
+}
+
+export const useSyncPlayerScoreInput = ({
+  opponentId,
+  totalRoundScore,
+  targetScore,
+  onScoreChange,
+}: UseSyncPlayerScoreInputParams) => {
+  const lastSyncedScoreRef = useRef<{
+    opponentId: number;
+    totalRoundScore: number;
+    score: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!totalRoundScore) {
+      lastSyncedScoreRef.current = null;
+      return;
+    }
+
+    const lastSyncedScore = lastSyncedScoreRef.current;
+
+    if (
+      lastSyncedScore?.opponentId === opponentId &&
+      lastSyncedScore.totalRoundScore === totalRoundScore &&
+      lastSyncedScore.score === targetScore
+    ) {
+      return;
+    }
+
+    onScoreChange(targetScore);
+    lastSyncedScoreRef.current = {
+      opponentId,
+      totalRoundScore,
+      score: targetScore,
+    };
+  }, [opponentId, onScoreChange, targetScore, totalRoundScore]);
+};

--- a/packages/hooks/tests/FeatureToggleProvider.test.ts
+++ b/packages/hooks/tests/FeatureToggleProvider.test.ts
@@ -17,6 +17,10 @@ const mocks = vi.hoisted(() => ({
   effectCleanups: [] as Array<(() => void) | void>,
 }));
 
+vi.mock("../src/usePointsTypeFeature", () => ({
+  useSyncPointsTypeFeature: vi.fn(),
+}));
+
 vi.mock("../src/featureToggles/featureToggleUtils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/featureToggles/featureToggleUtils")>();
 
@@ -62,7 +66,9 @@ describe("FeatureToggleProvider", () => {
 
     expect(element.type).toBe(FeatureToggleContext.Provider);
     expect(element.props.value).toEqual(FEATURE_TOGGLES);
-    expect(element.props.children).toBe("child");
+    expect(element.props.children).toEqual(
+      expect.arrayContaining(["child"]),
+    );
   });
 
   it("syncs centralized toggles on mount", async () => {

--- a/packages/hooks/tests/FeatureToggleProvider.test.ts
+++ b/packages/hooks/tests/FeatureToggleProvider.test.ts
@@ -88,10 +88,20 @@ describe("FeatureToggleProvider", () => {
     });
 
     await vi.waitFor(() => {
-      expect(mocks.setToggles).toHaveBeenCalledWith({
+      expect(mocks.setToggles).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    const updateToggles = mocks.setToggles.mock.calls[0]?.[0] as (
+      current: FeatureToggleState,
+    ) => FeatureToggleState;
+    expect(
+      updateToggles({
         ...FEATURE_TOGGLES,
-        "settings-screen": true,
-      });
+        "settings-screen": false,
+      }),
+    ).toEqual({
+      ...FEATURE_TOGGLES,
+      "settings-screen": true,
     });
   });
 

--- a/packages/hooks/tests/featureToggleUtils.test.ts
+++ b/packages/hooks/tests/featureToggleUtils.test.ts
@@ -20,6 +20,7 @@ describe("featureToggleUtils", () => {
 
   it("identifies known feature toggles", () => {
     expect(isKnownFeatureToggle("settings-screen")).toBe(true);
+    expect(isKnownFeatureToggle("points-type")).toBe(true);
     expect(isKnownFeatureToggle("unknown-toggle")).toBe(false);
   });
 

--- a/packages/hooks/tests/featureToggleUtils.test.ts
+++ b/packages/hooks/tests/featureToggleUtils.test.ts
@@ -6,6 +6,10 @@ import {
   getDefaultFeatureToggleState,
   isKnownFeatureToggle,
   logUnknownFeatureToggle,
+  areFeatureToggleStatesEqual,
+  needsFeatureToggleStorageSync,
+  parseStoredFeatureToggles,
+  serializeFeatureToggleState,
   syncFeatureTogglesToStorage,
 } from "../src/featureToggles/featureToggleUtils";
 
@@ -34,6 +38,63 @@ describe("featureToggleUtils", () => {
     );
   });
 
+  it("serializes feature toggles using centralized key order", () => {
+    expect(serializeFeatureToggleState(FEATURE_TOGGLES)).toBe(JSON.stringify(FEATURE_TOGGLES));
+  });
+
+  it("parses only known feature toggles from storage", () => {
+    expect(
+      parseStoredFeatureToggles(
+        JSON.stringify({
+          "settings-screen": true,
+          "backend-game-init": false,
+          "points-type": true,
+          "unknown-toggle": true,
+        }),
+      ),
+    ).toEqual({
+      "settings-screen": true,
+      "backend-game-init": false,
+      "points-type": true,
+    });
+  });
+
+  it("detects equivalent feature toggle states", () => {
+    expect(
+      areFeatureToggleStatesEqual(FEATURE_TOGGLES, { ...FEATURE_TOGGLES }),
+    ).toBe(true);
+  });
+
+  it("detects when storage is missing newly added feature toggles", () => {
+    expect(
+      needsFeatureToggleStorageSync(
+        JSON.stringify({
+          "settings-screen": true,
+          "backend-game-init": false,
+        }),
+        FEATURE_TOGGLES,
+      ),
+    ).toBe(true);
+  });
+
+  it("detects when stored values differ from centralized defaults", () => {
+    expect(
+      needsFeatureToggleStorageSync(
+        JSON.stringify({
+          ...FEATURE_TOGGLES,
+          "settings-screen": true,
+        }),
+        FEATURE_TOGGLES,
+      ),
+    ).toBe(true);
+  });
+
+  it("skips storage sync when all centralized toggles match storage", () => {
+    expect(
+      needsFeatureToggleStorageSync(JSON.stringify(FEATURE_TOGGLES), FEATURE_TOGGLES),
+    ).toBe(false);
+  });
+
   it("syncs centralized toggles to storage", async () => {
     const getFromStorage = vi.fn().mockResolvedValue(null);
     const setToStorage = vi.fn().mockResolvedValue(undefined);
@@ -46,7 +107,30 @@ describe("featureToggleUtils", () => {
     expect(getFromStorage).toHaveBeenCalledWith(StorageKeys.featureToggles);
     expect(setToStorage).toHaveBeenCalledWith(
       StorageKeys.featureToggles,
-      JSON.stringify(FEATURE_TOGGLES),
+      serializeFeatureToggleState(FEATURE_TOGGLES),
+    );
+    expect(syncedToggles).toEqual(FEATURE_TOGGLES);
+  });
+
+  it("updates storage when a new centralized toggle is missing from storage", async () => {
+    const getFromStorage = vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({
+          "settings-screen": true,
+          "backend-game-init": false,
+        }),
+      );
+    const setToStorage = vi.fn().mockResolvedValue(undefined);
+
+    const syncedToggles = await syncFeatureTogglesToStorage({
+      getFromStorage,
+      setToStorage,
+    });
+
+    expect(setToStorage).toHaveBeenCalledWith(
+      StorageKeys.featureToggles,
+      serializeFeatureToggleState(FEATURE_TOGGLES),
     );
     expect(syncedToggles).toEqual(FEATURE_TOGGLES);
   });
@@ -54,7 +138,7 @@ describe("featureToggleUtils", () => {
   it("skips storage write when centralized toggles are already synced", async () => {
     const getFromStorage = vi
       .fn()
-      .mockResolvedValue(JSON.stringify(FEATURE_TOGGLES));
+      .mockResolvedValue(serializeFeatureToggleState(FEATURE_TOGGLES));
     const setToStorage = vi.fn();
 
     await syncFeatureTogglesToStorage({
@@ -77,7 +161,7 @@ describe("featureToggleUtils", () => {
     expect(syncedToggles).toEqual(FEATURE_TOGGLES);
     expect(setToStorage).toHaveBeenCalledWith(
       StorageKeys.featureToggles,
-      JSON.stringify(FEATURE_TOGGLES),
+      serializeFeatureToggleState(FEATURE_TOGGLES),
     );
   });
 });

--- a/packages/hooks/tests/useFeatureToggle.test.ts
+++ b/packages/hooks/tests/useFeatureToggle.test.ts
@@ -52,7 +52,10 @@ describe("useFeatureToggle", () => {
   });
 
   it("returns false when toggle is disabled in context", async () => {
-    mocks.toggles = { ...FEATURE_TOGGLES };
+    mocks.toggles = {
+      ...FEATURE_TOGGLES,
+      "settings-screen": false,
+    };
 
     const { useFeatureToggle } = await import("../src/featureToggles/useFeatureToggle");
 

--- a/packages/hooks/tests/useHandleNextRound.test.ts
+++ b/packages/hooks/tests/useHandleNextRound.test.ts
@@ -54,6 +54,7 @@ vi.mock("@belot/store", () => ({
       players: mocks.players,
       teams: mocks.teams,
       mode: mocks.mode,
+      pointsType: "micropoints",
       roundsScores: mocks.roundsScores,
       updateRoundScore: mocks.updateRoundScore,
       dealer: mocks.dealer,

--- a/packages/hooks/tests/useHandleNextRound.test.ts
+++ b/packages/hooks/tests/useHandleNextRound.test.ts
@@ -49,7 +49,7 @@ vi.mock("react", () => ({
 }));
 
 vi.mock("../src/usePointsTypeFeature", () => ({
-  useIsPointsTypeEnabled: () => false,
+  useIsPointsTypeEnabled: () => true,
 }));
 
 vi.mock("@belot/store", () => ({
@@ -58,7 +58,7 @@ vi.mock("@belot/store", () => ({
       players: mocks.players,
       teams: mocks.teams,
       mode: mocks.mode,
-      pointsType: "micropoints",
+      pointsType: "points",
       roundsScores: mocks.roundsScores,
       updateRoundScore: mocks.updateRoundScore,
       dealer: mocks.dealer,
@@ -127,7 +127,13 @@ describe("useHandleNextRound", () => {
     handleDialogOpen(showDialog);
 
     const roundScoreHolder = mocks.stateHolders[1];
-    expect(roundScoreHolder.value).toEqual(mocks.roundsScores[0]);
+    const roundScore = roundScoreHolder.value as RoundScore;
+    expect(roundScore).toMatchObject({
+      id: 0,
+      totalRoundScore: 16,
+      roundPlayer: null,
+    });
+    expect(roundScore.playersScores.length).toBeGreaterThan(0);
     expect(showDialog).toHaveBeenCalledOnce();
   });
 

--- a/packages/hooks/tests/useHandleNextRound.test.ts
+++ b/packages/hooks/tests/useHandleNextRound.test.ts
@@ -48,6 +48,10 @@ vi.mock("react", () => ({
   useCallback: (callback: (...args: unknown[]) => unknown) => callback,
 }));
 
+vi.mock("../src/usePointsTypeFeature", () => ({
+  useIsPointsTypeEnabled: () => false,
+}));
+
 vi.mock("@belot/store", () => ({
   useGameStore: (selector: (state: unknown) => unknown) =>
     selector({

--- a/packages/hooks/tests/useHandleSkipRound.test.ts
+++ b/packages/hooks/tests/useHandleSkipRound.test.ts
@@ -22,6 +22,10 @@ vi.mock("react", () => ({
   useCallback: (callback: () => void) => callback,
 }));
 
+vi.mock("../src/usePointsTypeFeature", () => ({
+  useEffectivePointsType: () => "micropoints",
+}));
+
 vi.mock("@belot/store", () => ({
   useGameStore: (selector: (state: unknown) => unknown) => selector(mocks.state),
 }));

--- a/packages/hooks/tests/useHandleSkipRound.test.ts
+++ b/packages/hooks/tests/useHandleSkipRound.test.ts
@@ -52,6 +52,7 @@ describe("useHandleSkipRound", () => {
       players,
       teams: [],
       mode: GameMode.classic,
+      pointsType: "micropoints",
       roundsScores: [initialRound],
       dealer: players[0],
       skipRound: mocks.skipRound,

--- a/packages/hooks/tests/useLoadGameData.test.ts
+++ b/packages/hooks/tests/useLoadGameData.test.ts
@@ -3,6 +3,8 @@ import type { Player, RoundScore } from "@belot/types";
 
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
+import { useIsPointsTypeEnabled } from "../src/usePointsTypeFeature";
+
 const mocks = vi.hoisted(() => {
   const setPlayers = vi.fn();
   const setDealer = vi.fn();
@@ -87,6 +89,31 @@ describe("useLoadGameData", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("restores default settings when stored points type is invalid", async () => {
+    vi.mocked(useIsPointsTypeEnabled).mockReturnValue(true);
+
+    const setToStorage = vi.fn().mockResolvedValue(undefined);
+    const storage: Partial<Record<StorageKeys, string>> = {
+      [StorageKeys.settings]: JSON.stringify({ pointsType: "invalid" }),
+    };
+
+    const { useLoadGameData } = await import("../src/useLoadGameData");
+
+    useLoadGameData({
+      getFromStorage: (key) => storage[key] ?? null,
+      setToStorage,
+    });
+
+    await vi.waitFor(() => {
+      expect(setToStorage).toHaveBeenCalledWith(
+        StorageKeys.settings,
+        JSON.stringify({ pointsType: "micropoints" }),
+      );
+    });
+
+    expect(mocks.setPointsType).not.toHaveBeenCalled();
   });
 
   it("restores the saved dealer after rounds so hydration does not advance it", async () => {

--- a/packages/hooks/tests/useLoadGameData.test.ts
+++ b/packages/hooks/tests/useLoadGameData.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => {
   const setPlayers = vi.fn();
   const setDealer = vi.fn();
   const setRoundsScores = vi.fn();
+  const setPointsType = vi.fn();
   const stateHolders: { value: unknown }[] = [];
   const hasFetchedRef = { current: false };
 
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => {
     setPlayers,
     setDealer,
     setRoundsScores,
+    setPointsType,
     stateHolders,
     hasFetchedRef,
     storeState: {
@@ -57,6 +59,7 @@ vi.mock("@belot/store", () => ({
       setPlayers: mocks.setPlayers,
       setDealer: mocks.setDealer,
       setRoundsScores: mocks.setRoundsScores,
+      setPointsType: mocks.setPointsType,
     }),
 }));
 

--- a/packages/hooks/tests/useLoadGameData.test.ts
+++ b/packages/hooks/tests/useLoadGameData.test.ts
@@ -55,16 +55,24 @@ vi.mock("../src/usePointsTypeFeature", () => ({
 }));
 
 vi.mock("@belot/store", () => ({
-  useGameStore: (selector: (state: unknown) => unknown) =>
-    selector({
-      players: mocks.storeState.players,
-      dealer: mocks.storeState.dealer,
-      roundsScores: mocks.storeState.roundsScores,
-      setPlayers: mocks.setPlayers,
-      setDealer: mocks.setDealer,
-      setRoundsScores: mocks.setRoundsScores,
-      setPointsType: mocks.setPointsType,
-    }),
+  useGameStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        players: mocks.storeState.players,
+        dealer: mocks.storeState.dealer,
+        roundsScores: mocks.storeState.roundsScores,
+        pointsType: "micropoints",
+        setPlayers: mocks.setPlayers,
+        setDealer: mocks.setDealer,
+        setRoundsScores: mocks.setRoundsScores,
+        setPointsType: mocks.setPointsType,
+      }),
+    {
+      getState: () => ({
+        pointsType: "micropoints",
+      }),
+    },
+  ),
 }));
 
 describe("useLoadGameData", () => {
@@ -114,7 +122,19 @@ describe("useLoadGameData", () => {
     });
 
     expect(mocks.setPlayers).toHaveBeenCalledWith(players);
-    expect(mocks.setRoundsScores).toHaveBeenCalledWith(roundsScores);
+    expect(mocks.setRoundsScores).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 0,
+        totalRoundScore: 162,
+      }),
+    ]);
+    const restoredRoundsScores = mocks.setRoundsScores.mock
+      .calls[0]?.[0] as RoundScore[];
+    expect(restoredRoundsScores[0].playersScores).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ playerId: 0, score: 0 }),
+      ]),
+    );
     expect(mocks.setPlayers.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.setRoundsScores.mock.invocationCallOrder[0],
     );
@@ -153,7 +173,16 @@ describe("useLoadGameData", () => {
     });
 
     expect(mocks.stateHolders[1]?.value).toEqual(dealer);
-    expect(mocks.stateHolders[2]?.value).toEqual(roundsScores);
+    const loadedRoundsScores = mocks.stateHolders[2]?.value as RoundScore[];
+    expect(loadedRoundsScores[0]).toMatchObject({
+      id: 0,
+      totalRoundScore: 162,
+    });
+    expect(loadedRoundsScores[0].playersScores).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ playerId: 0, score: 0 }),
+      ]),
+    );
     expect(mocks.setPlayers).not.toHaveBeenCalled();
     expect(mocks.setDealer).not.toHaveBeenCalled();
     expect(mocks.setRoundsScores).not.toHaveBeenCalled();

--- a/packages/hooks/tests/useLoadGameData.test.ts
+++ b/packages/hooks/tests/useLoadGameData.test.ts
@@ -50,6 +50,10 @@ vi.mock("react", () => ({
   },
 }));
 
+vi.mock("../src/usePointsTypeFeature", () => ({
+  useIsPointsTypeEnabled: vi.fn(() => false),
+}));
+
 vi.mock("@belot/store", () => ({
   useGameStore: (selector: (state: unknown) => unknown) =>
     selector({

--- a/packages/hooks/tests/usePlayersSubmit.test.ts
+++ b/packages/hooks/tests/usePlayersSubmit.test.ts
@@ -16,9 +16,11 @@ const mocks = vi.hoisted(() => {
     setValidations: vi.fn(),
     setEmptyRoundScore: vi.fn(),
     setGameId: vi.fn(),
+    setPointsType: vi.fn(),
     navigateFunction: vi.fn(),
     setItemsToStorage: vi.fn(),
     getApiBaseUrl: vi.fn(() => "https://api.example"),
+    getFromStorage: vi.fn(() => null),
     handleCatchError: vi.fn(),
     mutate: vi.fn(),
   };
@@ -48,6 +50,7 @@ vi.mock("@belot/store", () => ({
       mode: mocks.mode,
       setEmptyRoundScore: mocks.setEmptyRoundScore,
       setGameId: mocks.setGameId,
+      setPointsType: mocks.setPointsType,
     }),
 }));
 
@@ -97,6 +100,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -114,6 +118,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -128,6 +133,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -165,6 +171,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -192,6 +199,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -209,6 +217,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 
@@ -231,6 +240,7 @@ describe("usePlayersSubmit", () => {
       navigateFunction: mocks.navigateFunction,
       setItemsToStorage: mocks.setItemsToStorage,
       getApiBaseUrl: mocks.getApiBaseUrl,
+      getFromStorage: mocks.getFromStorage,
       handleCatchError: mocks.handleCatchError,
     });
 

--- a/packages/hooks/tests/usePlayersSubmit.test.ts
+++ b/packages/hooks/tests/usePlayersSubmit.test.ts
@@ -58,6 +58,11 @@ vi.mock("../src/featureToggles/useFeatureToggle", () => ({
   useFeatureToggle: vi.fn(() => true),
 }));
 
+vi.mock("../src/usePointsTypeFeature", () => ({
+  useIsPointsTypeEnabled: () => false,
+  useEffectivePointsType: () => "micropoints",
+}));
+
 vi.mock("@belot/utils", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@belot/utils")>();
 

--- a/packages/hooks/tests/usePlayersSubmit.test.ts
+++ b/packages/hooks/tests/usePlayersSubmit.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => {
     mode: "classic",
     setValidations: vi.fn(),
     setEmptyRoundScore: vi.fn(),
+    setRoundsScores: vi.fn(),
     setGameId: vi.fn(),
     setPointsType: vi.fn(),
     navigateFunction: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock("@belot/store", () => ({
       dealer: mocks.dealer,
       mode: mocks.mode,
       setEmptyRoundScore: mocks.setEmptyRoundScore,
+      setRoundsScores: mocks.setRoundsScores,
       setGameId: mocks.setGameId,
       setPointsType: mocks.setPointsType,
     }),
@@ -144,7 +146,8 @@ describe("usePlayersSubmit", () => {
 
     await handleSubmit();
 
-    expect(mocks.setEmptyRoundScore).toHaveBeenCalledOnce();
+    expect(mocks.setPointsType).toHaveBeenCalled();
+    expect(mocks.setRoundsScores).toHaveBeenCalledOnce();
     expect(mocks.setItemsToStorage).toHaveBeenCalledWith(
       expect.objectContaining({
         [StorageKeys.timerStartTime]: "",
@@ -210,7 +213,7 @@ describe("usePlayersSubmit", () => {
 
     await handleSubmit();
 
-    expect(mocks.setEmptyRoundScore).not.toHaveBeenCalled();
+    expect(mocks.setRoundsScores).not.toHaveBeenCalled();
     expect(mocks.navigateFunction).not.toHaveBeenCalled();
   });
 

--- a/packages/hooks/tests/usePointsTypeFeature.test.ts
+++ b/packages/hooks/tests/usePointsTypeFeature.test.ts
@@ -53,6 +53,7 @@ describe("usePointsTypeFeature", () => {
   });
 
   it("resets store to micropoints when feature is disabled", async () => {
+    mocks.storePointsType = POINTS_TYPE[1].id;
     mocks.isPointsTypeEnabled = false;
 
     const { useSyncPointsTypeFeature } = await import("../src/usePointsTypeFeature");
@@ -60,5 +61,16 @@ describe("usePointsTypeFeature", () => {
     useSyncPointsTypeFeature();
 
     expect(mocks.setPointsType).toHaveBeenCalledWith(POINTS_TYPE[0].id);
+  });
+
+  it("does not reset store when points type is already micropoints", async () => {
+    mocks.storePointsType = POINTS_TYPE[0].id;
+    mocks.isPointsTypeEnabled = false;
+
+    const { useSyncPointsTypeFeature } = await import("../src/usePointsTypeFeature");
+
+    useSyncPointsTypeFeature();
+
+    expect(mocks.setPointsType).not.toHaveBeenCalled();
   });
 });

--- a/packages/hooks/tests/usePointsTypeFeature.test.ts
+++ b/packages/hooks/tests/usePointsTypeFeature.test.ts
@@ -1,0 +1,64 @@
+import { POINTS_TYPE } from "@belot/constants";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  storePointsType: "micropoints",
+  setPointsType: vi.fn(),
+  isPointsTypeEnabled: false,
+}));
+
+vi.mock("react", () => ({
+  useEffect: (effect: () => void) => {
+    effect();
+  },
+}));
+
+vi.mock("@belot/store", () => ({
+  useGameStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      pointsType: mocks.storePointsType,
+      setPointsType: mocks.setPointsType,
+    }),
+}));
+
+vi.mock("../src/featureToggles/useFeatureToggle", () => ({
+  useFeatureToggle: (name: string) =>
+    name === "points-type" ? mocks.isPointsTypeEnabled : false,
+}));
+
+describe("usePointsTypeFeature", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.storePointsType = POINTS_TYPE[0].id;
+    mocks.isPointsTypeEnabled = false;
+  });
+
+  it("returns micropoints when points type feature is disabled", async () => {
+    mocks.storePointsType = POINTS_TYPE[1].id;
+    mocks.isPointsTypeEnabled = false;
+
+    const { useEffectivePointsType } = await import("../src/usePointsTypeFeature");
+
+    expect(useEffectivePointsType()).toBe(POINTS_TYPE[0].id);
+  });
+
+  it("returns store points type when feature is enabled", async () => {
+    mocks.storePointsType = POINTS_TYPE[1].id;
+    mocks.isPointsTypeEnabled = true;
+
+    const { useEffectivePointsType } = await import("../src/usePointsTypeFeature");
+
+    expect(useEffectivePointsType()).toBe(POINTS_TYPE[1].id);
+  });
+
+  it("resets store to micropoints when feature is disabled", async () => {
+    mocks.isPointsTypeEnabled = false;
+
+    const { useSyncPointsTypeFeature } = await import("../src/usePointsTypeFeature");
+
+    useSyncPointsTypeFeature();
+
+    expect(mocks.setPointsType).toHaveBeenCalledWith(POINTS_TYPE[0].id);
+  });
+});

--- a/packages/hooks/tests/usePointsTypeSelection.test.ts
+++ b/packages/hooks/tests/usePointsTypeSelection.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  onChange: vi.fn(),
+  messages: {
+    settingsPointsType: "Points type",
+    settingsPointsTypeHint: "Hint",
+    settingsPointsTypeMicropoints: "Micropoints",
+    settingsPointsTypePoints: "Points",
+  },
+}));
+
+vi.mock("react", () => ({
+  useCallback: (callback: (...args: unknown[]) => unknown) => callback,
+}));
+
+vi.mock("@belot/localizations", () => ({
+  formatLocalizationKey: (localizationKey: string) =>
+    localizationKey
+      .split(".")
+      .map((keyPart, index) =>
+        index === 0 ? keyPart : keyPart.at(0)?.toUpperCase() + keyPart.substring(1),
+      )
+      .join(""),
+  useLocalizations: () => mocks.messages,
+}));
+
+describe("usePointsTypeSelection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("calls onChange only when value changes", async () => {
+    const { usePointsTypeSelection } = await import("../src/usePointsTypeSelection");
+
+    const { handleChange } = usePointsTypeSelection({
+      value: "micropoints",
+      onChange: mocks.onChange,
+    });
+
+    handleChange("micropoints");
+    handleChange("points");
+
+    expect(mocks.onChange).toHaveBeenCalledTimes(1);
+    expect(mocks.onChange).toHaveBeenCalledWith("points");
+  });
+
+  it("returns option labels from localization keys", async () => {
+    const { usePointsTypeSelection } = await import("../src/usePointsTypeSelection");
+
+    const { getOptionLabel } = usePointsTypeSelection({
+      value: "micropoints",
+      onChange: mocks.onChange,
+    });
+
+    expect(getOptionLabel("settings.points.type.points")).toBe("Points");
+  });
+
+  it("includes settings labels when requested", async () => {
+    const { usePointsTypeSelection } = await import("../src/usePointsTypeSelection");
+
+    const { messages } = usePointsTypeSelection({
+      value: "micropoints",
+      onChange: mocks.onChange,
+      includeSettingsLabels: true,
+    });
+
+    expect(messages.settingsPointsType).toBe("Points type");
+    expect(messages.settingsPointsTypeHint).toBe("Hint");
+  });
+});

--- a/packages/hooks/tests/useSyncPlayerScoreInput.test.ts
+++ b/packages/hooks/tests/useSyncPlayerScoreInput.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  onScoreChange: vi.fn(),
+  lastSyncedScoreRef: {
+    current: null as {
+      opponentId: number;
+      totalRoundScore: number;
+      score: number;
+    } | null,
+  },
+}));
+
+vi.mock("react", () => ({
+  useRef: () => mocks.lastSyncedScoreRef,
+  useEffect: (effect: () => void) => {
+    effect();
+  },
+}));
+
+describe("useSyncPlayerScoreInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.lastSyncedScoreRef.current = null;
+    vi.resetModules();
+  });
+
+  it("skips sync when total round score is zero", async () => {
+    const { useSyncPlayerScoreInput } = await import("../src/useSyncPlayerScoreInput");
+
+    useSyncPlayerScoreInput({
+      opponentId: 0,
+      totalRoundScore: 0,
+      targetScore: 0,
+      onScoreChange: mocks.onScoreChange,
+    });
+
+    expect(mocks.onScoreChange).not.toHaveBeenCalled();
+    expect(mocks.lastSyncedScoreRef.current).toBeNull();
+  });
+
+  it("syncs score when total round score is set", async () => {
+    const { useSyncPlayerScoreInput } = await import("../src/useSyncPlayerScoreInput");
+
+    useSyncPlayerScoreInput({
+      opponentId: 0,
+      totalRoundScore: 162,
+      targetScore: 25,
+      onScoreChange: mocks.onScoreChange,
+    });
+
+    expect(mocks.onScoreChange).toHaveBeenCalledWith(25);
+    expect(mocks.lastSyncedScoreRef.current).toEqual({
+      opponentId: 0,
+      totalRoundScore: 162,
+      score: 25,
+    });
+  });
+
+  it("skips redundant sync when score has not changed", async () => {
+    const { useSyncPlayerScoreInput } = await import("../src/useSyncPlayerScoreInput");
+
+    useSyncPlayerScoreInput({
+      opponentId: 0,
+      totalRoundScore: 162,
+      targetScore: 25,
+      onScoreChange: mocks.onScoreChange,
+    });
+
+    mocks.onScoreChange.mockClear();
+
+    useSyncPlayerScoreInput({
+      opponentId: 0,
+      totalRoundScore: 162,
+      targetScore: 25,
+      onScoreChange: mocks.onScoreChange,
+    });
+
+    expect(mocks.onScoreChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/localizations/src/en.json
+++ b/packages/localizations/src/en.json
@@ -10,7 +10,6 @@
   "next.round.player.display": "{0} played this round",
   "next.round.score": "Round score: {0}",
   "next.round.score.for.player": "Score for {0}",
-  "next.round.score.for.player.input.helper": "Please enter points",
   "next.round.button": "Next round",
   "win.dialog.title.player": "Player {0} won",
   "win.dialog.title.team": "Team {0} won",

--- a/packages/localizations/src/ro.json
+++ b/packages/localizations/src/ro.json
@@ -10,7 +10,6 @@
   "next.round.player.display": "{0} a jucat această rundă",
   "next.round.score": "Scor runda: {0}",
   "next.round.score.for.player": "Scor pentru {0}",
-  "next.round.score.for.player.input.helper": "Te rugăm să introduci microbile",
   "next.round.button": "Runda următoare",
   "win.dialog.title.player": "Jucător {0} a câștigat",
   "win.dialog.title.team": "Echipa {0} a câștigat",

--- a/packages/localizations/src/ru.json
+++ b/packages/localizations/src/ru.json
@@ -10,7 +10,6 @@
   "next.round.player.display": "{0} играл(а) в этом раунде",
   "next.round.score": "Очки за раунд: {0}",
   "next.round.score.for.player": "Очки для {0}",
-  "next.round.score.for.player.input.helper": "Пожалуйста, введите количество очков",
   "next.round.button": "Следующий раунд",
   "win.dialog.title.player": "Игрок {0} выиграл",
   "win.dialog.title.team": "Команда {0} выиграла",

--- a/packages/store/src/game.slice.ts
+++ b/packages/store/src/game.slice.ts
@@ -1,3 +1,4 @@
+import { POINTS_TYPE } from "@belot/constants";
 import { GameMode, type GameSlice } from "@belot/types";
 
 import type { StateCreator } from "zustand";
@@ -5,6 +6,8 @@ import type { StateCreator } from "zustand";
 export const createGameSlice: StateCreator<GameSlice> = (set) => ({
   mode: GameMode.classic,
   gameId: null,
+  pointsType: POINTS_TYPE[0].id,
 
   setGameId: (gameId) => set(() => ({ gameId })),
+  setPointsType: (pointsType) => set(() => ({ pointsType })),
 });

--- a/packages/store/src/game.ts
+++ b/packages/store/src/game.ts
@@ -1,3 +1,4 @@
+import { POINTS_TYPE } from "@belot/constants";
 import { GameMode, type GameSlice, type PlayersSlice, type RoundSlice } from "@belot/types";
 
 import { create } from "zustand";
@@ -20,6 +21,7 @@ export const createGameStore = () =>
       set(() => ({
         players: [],
         mode: GameMode.classic,
+        pointsType: POINTS_TYPE[0].id,
         dealer: null,
         roundsScores: [],
         teams: [],

--- a/packages/store/src/rounds.slice.ts
+++ b/packages/store/src/rounds.slice.ts
@@ -1,9 +1,9 @@
 import { type GameSlice, type PlayersSlice, type RoundSlice } from "@belot/types";
 import {
+  normalizeSkippedRoundScore,
   prepareEmptyRoundScoreRow,
   recalculateScoreOnRedo,
   recalculateScoreOnUndo,
-  roundByLastDigit,
   setNextDealer,
 } from "@belot/utils/src";
 
@@ -69,12 +69,16 @@ export const createRoundSlice: StateCreator<
 
       const lastIndex = roundsScoresCount - 1;
       const lastRoundScore = state.roundsScores[lastIndex];
+      const pointsType = state.pointsType ?? "micropoints";
 
       const updatedRoundsScores = [...state.roundsScores];
 
       updatedRoundsScores[lastIndex] = {
         ...lastRoundScore,
-        totalRoundScore: roundByLastDigit(lastRoundScore.totalRoundScore),
+        totalRoundScore: normalizeSkippedRoundScore(
+          lastRoundScore.totalRoundScore,
+          pointsType,
+        ),
       };
 
       const newEmptyRow = prepareEmptyRoundScoreRow({

--- a/packages/types/src/game.ts
+++ b/packages/types/src/game.ts
@@ -49,4 +49,5 @@ export interface SumOpponentPlayersScoresProps {
   roundPlayer?: Player | null;
   currentOpponent?: TeamScore | PlayerScore;
   shouldRoundScore?: boolean;
+  pointsType?: string;
 }

--- a/packages/types/src/gameStore.ts
+++ b/packages/types/src/gameStore.ts
@@ -3,8 +3,10 @@ import { GameMode, type Player, type RoundScore, type Team } from "./game";
 export interface GameSlice {
   mode: GameMode;
   gameId: string | null;
+  pointsType: string;
 
   setGameId: (gameId: string | null) => void;
+  setPointsType: (pointsType: string) => void;
 }
 
 export interface RoundSlice {

--- a/packages/utils/src/gameUtils/gameScoreHelpers.ts
+++ b/packages/utils/src/gameUtils/gameScoreHelpers.ts
@@ -1,14 +1,4 @@
-import { POINTS_TYPE } from "@belot/constants";
-import {
-  GameMode,
-  type Player,
-  type PlayerScore,
-  type PlayersSlice,
-  type RoundScore,
-  type RoundSlice,
-  type Team,
-  type TeamScore,
-} from "@belot/types";
+import { GameMode, type Player, type PlayerScore, type PlayersSlice, type RoundScore, type RoundSlice, type Team, type TeamScore } from "@belot/types";
 
 import { getNextWinningStep, getWinPoints } from "../pointsTypeHelpers";
 
@@ -71,10 +61,9 @@ const checkForPlayerWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
-  pointsType: string = POINTS_TYPE[0].id,
 ) => {
-  const winPoints = getWinPoints(pointsType);
-  const nextWinningStep = getNextWinningStep(pointsType);
+  const winPoints = getWinPoints();
+  const nextWinningStep = getNextWinningStep();
 
   const winner = calculatedRoundScore.playersScores.filter(
     (playerScore) =>
@@ -94,10 +83,9 @@ const checkForTeamWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
-  pointsType: string = POINTS_TYPE[0].id,
 ) => {
-  const winPoints = getWinPoints(pointsType);
-  const nextWinningStep = getNextWinningStep(pointsType);
+  const winPoints = getWinPoints();
+  const nextWinningStep = getNextWinningStep();
 
   const winner = calculatedRoundScore.teamsScores.filter(
     (teamScore) => teamScore.totalScore >= winPoints + gameOverflowCount * nextWinningStep,
@@ -118,7 +106,6 @@ export const checkForGameWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
-  pointsType: string = POINTS_TYPE[0].id,
 ) => {
   return gameMode === GameMode.classic
     ? checkForPlayerWinner(
@@ -126,13 +113,11 @@ export const checkForGameWinner = (
         calculatedRoundScore,
         gameOverflowCount,
         setGameOverflowCount,
-        pointsType,
       )
     : checkForTeamWinner(
         teams,
         calculatedRoundScore,
         gameOverflowCount,
         setGameOverflowCount,
-        pointsType,
       );
 };

--- a/packages/utils/src/gameUtils/gameScoreHelpers.ts
+++ b/packages/utils/src/gameUtils/gameScoreHelpers.ts
@@ -1,4 +1,4 @@
-import { NEXT_WINNING_STEP, WIN_POINTS } from "@belot/constants";
+import { POINTS_TYPE } from "@belot/constants";
 import {
   GameMode,
   type Player,
@@ -9,6 +9,8 @@ import {
   type Team,
   type TeamScore,
 } from "@belot/types";
+
+import { getNextWinningStep, getWinPoints } from "../pointsTypeHelpers";
 
 export const setNextDealer = (state: Partial<RoundSlice> & Partial<PlayersSlice>) => {
   if (state.roundsScores?.length === 0) {
@@ -69,9 +71,14 @@ const checkForPlayerWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
+  pointsType: string = POINTS_TYPE[0].id,
 ) => {
+  const winPoints = getWinPoints(pointsType);
+  const nextWinningStep = getNextWinningStep(pointsType);
+
   const winner = calculatedRoundScore.playersScores.filter(
-    (playerScore) => playerScore.totalScore >= WIN_POINTS + gameOverflowCount * NEXT_WINNING_STEP,
+    (playerScore) =>
+      playerScore.totalScore >= winPoints + gameOverflowCount * nextWinningStep,
   );
 
   if (winner.length > 1) {
@@ -87,9 +94,13 @@ const checkForTeamWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
+  pointsType: string = POINTS_TYPE[0].id,
 ) => {
+  const winPoints = getWinPoints(pointsType);
+  const nextWinningStep = getNextWinningStep(pointsType);
+
   const winner = calculatedRoundScore.teamsScores.filter(
-    (teamScore) => teamScore.totalScore >= WIN_POINTS + gameOverflowCount * NEXT_WINNING_STEP,
+    (teamScore) => teamScore.totalScore >= winPoints + gameOverflowCount * nextWinningStep,
   );
 
   if (winner.length > 1) {
@@ -107,8 +118,21 @@ export const checkForGameWinner = (
   calculatedRoundScore: RoundScore,
   gameOverflowCount: number,
   setGameOverflowCount: (value: number | ((prev: number) => number)) => void,
+  pointsType: string = POINTS_TYPE[0].id,
 ) => {
   return gameMode === GameMode.classic
-    ? checkForPlayerWinner(players, calculatedRoundScore, gameOverflowCount, setGameOverflowCount)
-    : checkForTeamWinner(teams, calculatedRoundScore, gameOverflowCount, setGameOverflowCount);
+    ? checkForPlayerWinner(
+        players,
+        calculatedRoundScore,
+        gameOverflowCount,
+        setGameOverflowCount,
+        pointsType,
+      )
+    : checkForTeamWinner(
+        teams,
+        calculatedRoundScore,
+        gameOverflowCount,
+        setGameOverflowCount,
+        pointsType,
+      );
 };

--- a/packages/utils/src/gameUtils/playersScoreCalculationHelpers.ts
+++ b/packages/utils/src/gameUtils/playersScoreCalculationHelpers.ts
@@ -1,23 +1,35 @@
-import { BOLT_COUNT_LIMIT, BOLT_POINTS } from "@belot/constants";
+import { BOLT_COUNT_LIMIT, BOLT_POINTS, POINTS_TYPE } from "@belot/constants";
 import type { Player, PlayerScore, SumOpponentPlayersScoresProps } from "@belot/types";
 
-import { roundByLastDigit } from "../commonUtils";
+import {
+  getBoltTotalPenalty,
+  getZeroScorePenalty,
+  isMicropointsMode,
+  roundScoreValue,
+} from "../pointsTypeHelpers";
 
 export const calculatePlayersScoresHelper = (
   playersScores: PlayerScore[],
   roundPlayer: Player | null,
   totalRoundScore: number,
   shouldRoundScore?: boolean,
+  pointsType: string = POINTS_TYPE[0].id,
 ): PlayerScore[] => {
+  const useMicropointRounding = isMicropointsMode(pointsType);
+  const zeroScorePenalty = getZeroScorePenalty(pointsType);
+  const boltTotalPenalty = getBoltTotalPenalty(pointsType);
+
   const playerWithHighestScore = getPlayerWithHighestScore(
     playersScores,
     roundPlayer,
     shouldRoundScore,
+    pointsType,
   );
   const roundPlayerScore = sumOpponentPlayersScores({
     roundScore: { playersScores, totalRoundScore },
     roundPlayer,
     shouldRoundScore,
+    pointsType,
   });
   const shouldApplyBolt =
     !!playerWithHighestScore && roundPlayerScore < playerWithHighestScore.score;
@@ -25,7 +37,9 @@ export const calculatePlayersScoresHelper = (
     .filter((playerScore) => playerScore.playerId !== roundPlayer?.id)
     .map((playerScore) => ({
       playerId: playerScore.playerId,
-      score: shouldRoundScore ? roundByLastDigit(playerScore.score) : playerScore.score,
+      score: shouldRoundScore
+        ? roundScoreValue(playerScore.score, pointsType)
+        : playerScore.score,
     }));
   const highestOpponentScore = Math.max(
     ...opponentsWithComparableScores.map((playerScore) => playerScore.score),
@@ -42,7 +56,7 @@ export const calculatePlayersScoresHelper = (
 
   return playersScores.map((playerScore) => {
     const { score, boltCount, totalScore, playerId } = playerScore;
-    const roundedScore = shouldRoundScore ? roundByLastDigit(score) : score;
+    const roundedScore = shouldRoundScore ? roundScoreValue(score, pointsType) : score;
 
     if (roundPlayer?.id === playerId) {
       if (shouldApplyBolt) {
@@ -59,14 +73,17 @@ export const calculatePlayersScoresHelper = (
           ...playerScore,
           score: BOLT_POINTS,
           boltCount: boltCount + 1,
-          totalScore: boltCount + 1 === BOLT_COUNT_LIMIT ? totalScore - 10 : totalScore,
+          totalScore: boltCount + 1 === BOLT_COUNT_LIMIT ? totalScore + boltTotalPenalty : totalScore,
         };
       } else {
+        const finalRoundPlayerScore = shouldRoundScore
+          ? roundPlayerScore
+          : roundScoreValue(roundPlayerScore, pointsType);
+
         return {
           ...playerScore,
-          score: shouldRoundScore ? roundPlayerScore : roundByLastDigit(roundPlayerScore),
-          totalScore:
-            totalScore + (shouldRoundScore ? roundPlayerScore : roundByLastDigit(roundPlayerScore)),
+          score: finalRoundPlayerScore,
+          totalScore: totalScore + finalRoundPlayerScore,
         };
       }
     }
@@ -74,8 +91,8 @@ export const calculatePlayersScoresHelper = (
     if (shouldApplyBolt && highestOpponentPlayerIds.includes(playerId)) {
       const sharedScoreIndex = highestOpponentPlayerIds.indexOf(playerId);
       const sharedBonus = sharedBoltScore + (sharedScoreIndex < sharedBoltScoreRemainder ? 1 : 0);
-      const finalScore = !shouldRoundScore
-        ? roundByLastDigit(roundedScore + sharedBonus)
+      const finalScore = useMicropointRounding && !shouldRoundScore
+        ? roundScoreValue(roundedScore + sharedBonus, pointsType)
         : roundedScore + sharedBonus;
 
       return {
@@ -88,16 +105,18 @@ export const calculatePlayersScoresHelper = (
     if (roundedScore === 0) {
       return {
         ...playerScore,
-        score: -10,
-        totalScore: totalScore - 10,
+        score: zeroScorePenalty,
+        totalScore: totalScore + zeroScorePenalty,
         boltCount,
       };
     }
 
+    const finalScore = roundScoreValue(score, pointsType);
+
     return {
       ...playerScore,
-      score: roundByLastDigit(score),
-      totalScore: totalScore + roundByLastDigit(score),
+      score: finalScore,
+      totalScore: totalScore + finalScore,
     };
   });
 };
@@ -106,12 +125,24 @@ export const calculatePlayersScores = (
   playersScores: PlayerScore[],
   roundPlayer: Player | null,
   totalRoundScore: number,
+  pointsType: string = POINTS_TYPE[0].id,
 ): PlayerScore[] => {
+  if (!isMicropointsMode(pointsType)) {
+    return calculatePlayersScoresHelper(
+      playersScores,
+      roundPlayer,
+      totalRoundScore,
+      false,
+      pointsType,
+    );
+  }
+
   const calculatedRoundedPlayersScores = calculatePlayersScoresHelper(
     playersScores,
     roundPlayer,
     totalRoundScore,
     true,
+    pointsType,
   );
 
   const roundedRoundPlayerScore = calculatedRoundedPlayersScores.find(
@@ -123,7 +154,13 @@ export const calculatePlayersScores = (
   );
 
   if (isRoundPlayerTiedOnRoundedScore) {
-    return calculatePlayersScoresHelper(playersScores, roundPlayer, totalRoundScore);
+    return calculatePlayersScoresHelper(
+      playersScores,
+      roundPlayer,
+      totalRoundScore,
+      false,
+      pointsType,
+    );
   }
 
   return calculatedRoundedPlayersScores;
@@ -134,6 +171,7 @@ export const sumOpponentPlayersScores = ({
   currentOpponent,
   roundPlayer,
   shouldRoundScore,
+  pointsType = POINTS_TYPE[0].id,
 }: SumOpponentPlayersScoresProps) => {
   const { playersScores, totalRoundScore } = roundScore;
 
@@ -146,11 +184,11 @@ export const sumOpponentPlayersScores = ({
       return acc;
     }
 
-    return acc + (shouldRoundScore ? roundByLastDigit(playerScore.score) : playerScore.score);
+    return acc + (shouldRoundScore ? roundScoreValue(playerScore.score, pointsType) : playerScore.score);
   }, 0);
 
   if (totalRoundScore && shouldRoundScore) {
-    return roundByLastDigit(totalRoundScore) - sumScores;
+    return roundScoreValue(totalRoundScore, pointsType) - sumScores;
   }
 
   if (totalRoundScore) {
@@ -164,6 +202,7 @@ const getPlayerWithHighestScore = (
   playersScores: PlayerScore[],
   roundPlayer: Player | null,
   shouldRoundScore?: boolean,
+  pointsType: string = POINTS_TYPE[0].id,
 ): PlayerScore | undefined => {
   const playerWithHighestScore = playersScores
     .filter((playerScore) => playerScore.playerId !== roundPlayer?.id)
@@ -173,7 +212,7 @@ const getPlayerWithHighestScore = (
   if (playerWithHighestScore && shouldRoundScore) {
     return {
       ...playerWithHighestScore,
-      score: roundByLastDigit(playerWithHighestScore.score),
+      score: roundScoreValue(playerWithHighestScore.score, pointsType),
     };
   }
 

--- a/packages/utils/src/gameUtils/pointCellsHelpers.ts
+++ b/packages/utils/src/gameUtils/pointCellsHelpers.ts
@@ -1,21 +1,35 @@
-import { BOLT_COUNT_LIMIT, BOLT_POINTS } from "@belot/constants";
+import { BOLT_COUNT_LIMIT, BOLT_POINTS, POINTS_TYPE } from "@belot/constants";
 import type { BaseScore } from "@belot/types";
+
+import { getBoltLimitDisplayPenalty } from "../pointsTypeHelpers";
 
 export const getScore = (score: BaseScore) => {
   if (score.score === BOLT_POINTS) return `BT-${score.boltCount}`;
   return score.totalScore;
 };
 
-export const getCurrentScore = (score: BaseScore) => {
-  if (score.score === BOLT_POINTS) return score.boltCount === BOLT_COUNT_LIMIT ? "-10" : "";
+export const getCurrentScore = (score: BaseScore, pointsType: string = POINTS_TYPE[0].id) => {
+  const boltLimitDisplayPenalty = getBoltLimitDisplayPenalty(pointsType);
+
+  if (score.score === BOLT_POINTS) {
+    return score.boltCount === BOLT_COUNT_LIMIT ? boltLimitDisplayPenalty : "";
+  }
   if (score.score > 0) return `+${score.score}`;
   return score.score;
 };
 
-export const getCurrentScoreColor = (score: BaseScore, isMobile = false) => {
-  const currentScore = getCurrentScore(score);
+export const getCurrentScoreColor = (
+  score: BaseScore,
+  isMobile = false,
+  pointsType: string = POINTS_TYPE[0].id,
+) => {
+  const currentScore = getCurrentScore(score, pointsType);
+  const boltLimitDisplayPenalty = getBoltLimitDisplayPenalty(pointsType);
 
-  if (Number(currentScore) === -10 || currentScore.toString().includes("BT-")) {
+  if (
+    Number(currentScore) === Number(boltLimitDisplayPenalty) ||
+    currentScore.toString().includes("BT-")
+  ) {
     return isMobile ? "text-error-500" : "text-destructive";
   }
 

--- a/packages/utils/src/gameUtils/prepareStates.ts
+++ b/packages/utils/src/gameUtils/prepareStates.ts
@@ -13,6 +13,20 @@ import {
 
 import { getDefaultRoundPoints } from "../pointsTypeHelpers";
 
+const getTeamsFromState = (
+  state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
+): Team[] => {
+  if (state.teams && state.teams.length > 0) {
+    return state.teams;
+  }
+
+  if (state.players && state.mode === GameMode.teams) {
+    return prepareTeams(state.players, state.mode);
+  }
+
+  return [];
+};
+
 const preparePlayersScores = (
   state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
 ): PlayerScore[] => {
@@ -22,7 +36,7 @@ const preparePlayersScores = (
 
   if (mode === GameMode.teams || !players) return [];
 
-  if (lastRoundScore === undefined) {
+  if (lastRoundScore === undefined || lastRoundScore.playersScores.length === 0) {
     return players.map((player, index) => ({
       id: index,
       playerId: player.id,
@@ -46,12 +60,13 @@ const preparePlayersScores = (
 const prepareTeamsScores = (
   state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
 ): TeamScore[] => {
-  const { mode, teams, roundsScores } = state;
+  const { mode, roundsScores } = state;
+  const teams = getTeamsFromState(state);
   const lastRoundScore = roundsScores?.at(-1);
 
-  if (mode === GameMode.classic || !teams) return [];
+  if (mode === GameMode.classic || teams.length === 0) return [];
 
-  if (lastRoundScore === undefined) {
+  if (lastRoundScore === undefined || lastRoundScore.teamsScores.length === 0) {
     return teams.map((team, index) => ({
       id: index,
       teamId: team.id,
@@ -84,6 +99,21 @@ export const prepareEmptyRoundScoreRow = (
     teamsScores: prepareTeamsScores(state),
     totalRoundScore: getDefaultRoundPoints(pointsType),
     roundPlayer: null,
+  };
+};
+
+export const repairRoundScoreScores = (
+  roundScore: RoundScore,
+  state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
+): RoundScore => {
+  const previousRounds = state.roundsScores?.slice(0, -1) ?? [];
+  const template = prepareEmptyRoundScoreRow({ ...state, roundsScores: previousRounds });
+
+  return {
+    ...roundScore,
+    playersScores:
+      roundScore.playersScores.length > 0 ? roundScore.playersScores : template.playersScores,
+    teamsScores: roundScore.teamsScores.length > 0 ? roundScore.teamsScores : template.teamsScores,
   };
 };
 

--- a/packages/utils/src/gameUtils/prepareStates.ts
+++ b/packages/utils/src/gameUtils/prepareStates.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ROUND_POINTS } from "@belot/constants";
+import { POINTS_TYPE } from "@belot/constants";
 import {
   GameMode,
   type GameSlice,
@@ -10,6 +10,8 @@ import {
   type Team,
   type TeamScore,
 } from "@belot/types";
+
+import { getDefaultRoundPoints } from "../pointsTypeHelpers";
 
 const preparePlayersScores = (
   state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
@@ -74,12 +76,13 @@ export const prepareEmptyRoundScoreRow = (
   state: Partial<RoundSlice> & Partial<PlayersSlice> & Partial<GameSlice>,
 ): RoundScore => {
   const lastRoundScore = state.roundsScores?.at(-1);
+  const pointsType = state.pointsType ?? POINTS_TYPE[0].id;
 
   return {
     id: lastRoundScore?.id !== undefined ? lastRoundScore.id + 1 : 0,
     playersScores: preparePlayersScores(state),
     teamsScores: prepareTeamsScores(state),
-    totalRoundScore: DEFAULT_ROUND_POINTS,
+    totalRoundScore: getDefaultRoundPoints(pointsType),
     roundPlayer: null,
   };
 };
@@ -87,6 +90,7 @@ export const prepareEmptyRoundScoreRow = (
 export const preparePreviousRoundScoreRow = (
   previousRoundScore: RoundScore,
   undoneRoundScore: RoundScore,
+  pointsType: string = POINTS_TYPE[0].id,
 ): RoundScore => {
   return {
     id: undoneRoundScore.id,
@@ -98,7 +102,7 @@ export const preparePreviousRoundScoreRow = (
       ...teamScore,
       score: 0,
     })),
-    totalRoundScore: DEFAULT_ROUND_POINTS,
+    totalRoundScore: getDefaultRoundPoints(pointsType),
     roundPlayer: null,
   };
 };

--- a/packages/utils/src/gameUtils/scoreCalculationHelpers.ts
+++ b/packages/utils/src/gameUtils/scoreCalculationHelpers.ts
@@ -1,4 +1,4 @@
-import { LIMIT_OF_ROUND_POINTS } from "@belot/constants";
+import { POINTS_TYPE } from "@belot/constants";
 import {
   GameMode,
   type GameSlice,
@@ -8,7 +8,11 @@ import {
   type RoundSlice,
 } from "@belot/types";
 
-import { removeNthElementFromEnd, roundToDecimal } from "../commonUtils";
+import { removeNthElementFromEnd } from "../commonUtils";
+import {
+  finalizeTotalRoundScore,
+  getLimitOfRoundPoints,
+} from "../pointsTypeHelpers";
 import { setNextDealer, setPreviousDealer } from "./gameScoreHelpers";
 import { calculatePlayersScores } from "./playersScoreCalculationHelpers";
 import { prepareEmptyRoundScoreRow, preparePreviousRoundScoreRow } from "./prepareStates";
@@ -18,19 +22,30 @@ export const calculateRoundScore = (
   roundScore: RoundScore,
   roundPlayer: Player | null,
   gameMode: GameMode,
+  pointsType: string = POINTS_TYPE[0].id,
 ) => {
   return {
     ...roundScore,
     roundPlayer,
     playersScores:
       gameMode === GameMode.classic
-        ? calculatePlayersScores(roundScore.playersScores, roundPlayer, roundScore.totalRoundScore)
+        ? calculatePlayersScores(
+            roundScore.playersScores,
+            roundPlayer,
+            roundScore.totalRoundScore,
+            pointsType,
+          )
         : [],
     teamsScores:
       gameMode === GameMode.teams
-        ? calculateTeamsScore(roundScore.teamsScores, roundPlayer, roundScore.totalRoundScore)
+        ? calculateTeamsScore(
+            roundScore.teamsScores,
+            roundPlayer,
+            roundScore.totalRoundScore,
+            pointsType,
+          )
         : [],
-    totalRoundScore: roundToDecimal(roundScore.totalRoundScore),
+    totalRoundScore: finalizeTotalRoundScore(roundScore.totalRoundScore, pointsType),
   };
 };
 
@@ -38,8 +53,10 @@ export const calculateTotalRoundScore = (
   operationSign: string,
   roundPoint: number,
   prev: RoundScore,
+  pointsType: string = POINTS_TYPE[0].id,
 ): RoundScore => {
   let totalRoundScore = prev.totalRoundScore;
+  const limits = getLimitOfRoundPoints(pointsType);
 
   if (operationSign === "+") {
     totalRoundScore += roundPoint;
@@ -47,12 +64,12 @@ export const calculateTotalRoundScore = (
     totalRoundScore -= roundPoint;
   }
 
-  if (totalRoundScore >= LIMIT_OF_ROUND_POINTS.positive) {
-    totalRoundScore = LIMIT_OF_ROUND_POINTS.positive;
+  if (totalRoundScore >= limits.positive) {
+    totalRoundScore = limits.positive;
   }
 
-  if (totalRoundScore <= LIMIT_OF_ROUND_POINTS.negative) {
-    totalRoundScore = LIMIT_OF_ROUND_POINTS.negative;
+  if (totalRoundScore <= limits.negative) {
+    totalRoundScore = limits.negative;
   }
 
   return {
@@ -64,7 +81,7 @@ export const calculateTotalRoundScore = (
 export const recalculateScoreOnUndo = (
   state: RoundSlice & Partial<PlayersSlice> & Partial<GameSlice>,
 ): Pick<RoundSlice, "roundsScores" | "undoneRoundsScores"> => {
-  const { roundsScores, undoneRoundsScores } = state;
+  const { roundsScores, undoneRoundsScores, pointsType = POINTS_TYPE[0].id } = state;
 
   const undoneRoundScore = roundsScores.at(-2);
   let previousRoundScore = roundsScores.at(-3);
@@ -88,7 +105,7 @@ export const recalculateScoreOnUndo = (
   return {
     roundsScores: [
       ...adjustedRoundsScores,
-      preparePreviousRoundScoreRow(previousRoundScore, undoneRoundScore),
+      preparePreviousRoundScoreRow(previousRoundScore, undoneRoundScore, pointsType),
     ],
     undoneRoundsScores: [...undoneRoundsScores, undoneRoundScore],
     ...setPreviousDealer(state),

--- a/packages/utils/src/gameUtils/teamsScoreCalculationHelpers.ts
+++ b/packages/utils/src/gameUtils/teamsScoreCalculationHelpers.ts
@@ -1,13 +1,21 @@
-import { BOLT_COUNT_LIMIT, BOLT_POINTS } from "@belot/constants";
+import { BOLT_COUNT_LIMIT, BOLT_POINTS, POINTS_TYPE } from "@belot/constants";
 import type { Player, TeamScore } from "@belot/types";
 
-import { roundByLastDigit } from "../commonUtils";
+import {
+  getBoltTotalPenalty,
+  getZeroScorePenalty,
+  roundScoreValue,
+} from "../pointsTypeHelpers";
 
 export const calculateTeamsScore = (
   teamsScores: TeamScore[],
   roundPlayer: Player | null,
   totalRoundScore: number,
+  pointsType: string = POINTS_TYPE[0].id,
 ): TeamScore[] => {
+  const zeroScorePenalty = getZeroScorePenalty(pointsType);
+  const boltTotalPenalty = getBoltTotalPenalty(pointsType);
+
   return teamsScores.map((teamScore) => {
     const { score, boltCount, totalScore, teamId } = teamScore;
     const halfScore = totalRoundScore / 2;
@@ -30,30 +38,34 @@ export const calculateTeamsScore = (
         ...teamScore,
         score: BOLT_POINTS,
         boltCount: boltCount + 1,
-        totalScore: boltCount + 1 === BOLT_COUNT_LIMIT ? totalScore - 10 : totalScore,
+        totalScore: boltCount + 1 === BOLT_COUNT_LIMIT ? totalScore + boltTotalPenalty : totalScore,
       };
     }
 
     if (!isOwnTeam && !isScoreLowerThanHalfOfTotalScore && !isEqualScore) {
+      const finalScore = roundScoreValue(totalRoundScore, pointsType);
+
       return {
         ...teamScore,
-        score: roundByLastDigit(totalRoundScore),
-        totalScore: totalScore + roundByLastDigit(totalRoundScore),
+        score: finalScore,
+        totalScore: totalScore + finalScore,
       };
     }
 
     if (score === 0) {
       return {
         ...teamScore,
-        score: -10,
-        totalScore: totalScore - 10,
+        score: zeroScorePenalty,
+        totalScore: totalScore + zeroScorePenalty,
       };
     }
 
+    const finalScore = roundScoreValue(score, pointsType);
+
     return {
       ...teamScore,
-      score: roundByLastDigit(score),
-      totalScore: totalScore + roundByLastDigit(score),
+      score: finalScore,
+      totalScore: totalScore + finalScore,
     };
   });
 };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./commonUtils";
 export * from "./playersUtils";
+export * from "./pointsTypeHelpers";
 export * from "./gameUtils";

--- a/packages/utils/src/pointsTypeHelpers.ts
+++ b/packages/utils/src/pointsTypeHelpers.ts
@@ -6,6 +6,7 @@ import {
   ROUND_POINTS,
   WIN_POINTS,
 } from "@belot/constants";
+import type { RoundScore } from "@belot/types";
 
 import { roundByLastDigit, roundToDecimal } from "./commonUtils";
 
@@ -25,11 +26,12 @@ export const getLimitOfRoundPoints = (pointsType: string) =>
 export const getRoundPointsPresets = (pointsType: string) =>
   isMicropointsMode(pointsType) ? ROUND_POINTS : ROUND_POINTS.map(roundToDecimal);
 
-export const getWinPoints = (pointsType: string) =>
-  isMicropointsMode(pointsType) ? WIN_POINTS : roundToDecimal(WIN_POINTS);
+export const formatRoundPointPresetForDisplay = (roundPoint: number, pointsType: string) =>
+  isMicropointsMode(pointsType) ? roundToDecimal(roundPoint) : roundPoint;
 
-export const getNextWinningStep = (pointsType: string) =>
-  isMicropointsMode(pointsType) ? NEXT_WINNING_STEP : roundToDecimal(NEXT_WINNING_STEP);
+export const getWinPoints = () => WIN_POINTS;
+
+export const getNextWinningStep = () => NEXT_WINNING_STEP;
 
 export const formatTotalRoundScoreForDisplay = (totalRoundScore: number, pointsType: string) =>
   isMicropointsMode(pointsType) && String(totalRoundScore).length === 3
@@ -56,3 +58,61 @@ export const getBoltLimitDisplayPenalty = (pointsType: string) =>
 
 export const roundScoreValue = (score: number, pointsType: string) =>
   isMicropointsMode(pointsType) ? roundByLastDigit(score) : score;
+
+export const convertScoreValueForPointsType = (
+  score: number,
+  fromPointsType: string,
+  toPointsType: string,
+) => {
+  if (fromPointsType === toPointsType) {
+    return score;
+  }
+
+  if (isMicropointsMode(fromPointsType)) {
+    return roundToDecimal(score);
+  }
+
+  return score * 10;
+};
+
+const clampTotalRoundScore = (totalRoundScore: number, pointsType: string) => {
+  const limits = getLimitOfRoundPoints(pointsType);
+
+  if (totalRoundScore >= limits.positive) {
+    return limits.positive;
+  }
+
+  if (totalRoundScore <= limits.negative) {
+    return limits.negative;
+  }
+
+  return totalRoundScore;
+};
+
+export const convertRoundScoreForPointsType = (
+  roundScore: RoundScore,
+  fromPointsType: string,
+  toPointsType: string,
+): RoundScore => {
+  if (fromPointsType === toPointsType) {
+    return roundScore;
+  }
+
+  const totalRoundScore = clampTotalRoundScore(
+    convertScoreValueForPointsType(roundScore.totalRoundScore, fromPointsType, toPointsType),
+    toPointsType,
+  );
+
+  return {
+    ...roundScore,
+    totalRoundScore,
+    playersScores: roundScore.playersScores.map((playerScore) => ({
+      ...playerScore,
+      score: convertScoreValueForPointsType(playerScore.score, fromPointsType, toPointsType),
+    })),
+    teamsScores: roundScore.teamsScores.map((teamScore) => ({
+      ...teamScore,
+      score: convertScoreValueForPointsType(teamScore.score, fromPointsType, toPointsType),
+    })),
+  };
+};

--- a/packages/utils/src/pointsTypeHelpers.ts
+++ b/packages/utils/src/pointsTypeHelpers.ts
@@ -12,6 +12,36 @@ import { roundByLastDigit, roundToDecimal } from "./commonUtils";
 
 export const isMicropointsMode = (pointsType: string) => pointsType === POINTS_TYPE[0].id;
 
+export const isValidPointsType = (pointsType: string) =>
+  POINTS_TYPE.some((type) => type.id === pointsType);
+
+export const getDefaultPointsType = () => POINTS_TYPE[0].id;
+
+export const parseStoredPointsType = (storageSettings: string): string | null => {
+  try {
+    const parsedSettings = JSON.parse(storageSettings) as { pointsType?: unknown };
+
+    if (typeof parsedSettings.pointsType !== "string") {
+      console.warn(
+        "[Settings] Stored settings are missing a valid pointsType. Falling back to default.",
+      );
+      return null;
+    }
+
+    if (!isValidPointsType(parsedSettings.pointsType)) {
+      console.warn(
+        `[Settings] Stored points type "${parsedSettings.pointsType}" is invalid. Falling back to default.`,
+      );
+      return null;
+    }
+
+    return parsedSettings.pointsType;
+  } catch (error) {
+    console.error("[Settings] Failed to parse stored settings. Falling back to default.", error);
+    return null;
+  }
+};
+
 export const getDefaultRoundPoints = (pointsType: string) =>
   isMicropointsMode(pointsType) ? DEFAULT_ROUND_POINTS : roundToDecimal(DEFAULT_ROUND_POINTS);
 

--- a/packages/utils/src/pointsTypeHelpers.ts
+++ b/packages/utils/src/pointsTypeHelpers.ts
@@ -1,0 +1,58 @@
+import {
+  DEFAULT_ROUND_POINTS,
+  LIMIT_OF_ROUND_POINTS,
+  NEXT_WINNING_STEP,
+  POINTS_TYPE,
+  ROUND_POINTS,
+  WIN_POINTS,
+} from "@belot/constants";
+
+import { roundByLastDigit, roundToDecimal } from "./commonUtils";
+
+export const isMicropointsMode = (pointsType: string) => pointsType === POINTS_TYPE[0].id;
+
+export const getDefaultRoundPoints = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? DEFAULT_ROUND_POINTS : roundToDecimal(DEFAULT_ROUND_POINTS);
+
+export const getLimitOfRoundPoints = (pointsType: string) =>
+  isMicropointsMode(pointsType)
+    ? LIMIT_OF_ROUND_POINTS
+    : {
+        positive: roundToDecimal(LIMIT_OF_ROUND_POINTS.positive),
+        negative: roundToDecimal(LIMIT_OF_ROUND_POINTS.negative),
+      };
+
+export const getRoundPointsPresets = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? ROUND_POINTS : ROUND_POINTS.map(roundToDecimal);
+
+export const getWinPoints = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? WIN_POINTS : roundToDecimal(WIN_POINTS);
+
+export const getNextWinningStep = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? NEXT_WINNING_STEP : roundToDecimal(NEXT_WINNING_STEP);
+
+export const formatTotalRoundScoreForDisplay = (totalRoundScore: number, pointsType: string) =>
+  isMicropointsMode(pointsType) && String(totalRoundScore).length === 3
+    ? roundToDecimal(totalRoundScore)
+    : totalRoundScore;
+
+export const finalizeTotalRoundScore = (totalRoundScore: number, pointsType: string) =>
+  isMicropointsMode(pointsType) ? roundToDecimal(totalRoundScore) : totalRoundScore;
+
+export const normalizeSkippedRoundScore = (totalRoundScore: number, pointsType: string) =>
+  isMicropointsMode(pointsType) ? roundByLastDigit(totalRoundScore) : totalRoundScore;
+
+export const getScoreInputMaxLength = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? 3 : 2;
+
+export const getZeroScorePenalty = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? -10 : -1;
+
+export const getBoltTotalPenalty = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? -10 : -1;
+
+export const getBoltLimitDisplayPenalty = (pointsType: string) =>
+  isMicropointsMode(pointsType) ? "-10" : "-1";
+
+export const roundScoreValue = (score: number, pointsType: string) =>
+  isMicropointsMode(pointsType) ? roundByLastDigit(score) : score;

--- a/packages/utils/src/pointsTypeHelpers.ts
+++ b/packages/utils/src/pointsTypeHelpers.ts
@@ -15,6 +15,17 @@ export const isMicropointsMode = (pointsType: string) => pointsType === POINTS_T
 export const getDefaultRoundPoints = (pointsType: string) =>
   isMicropointsMode(pointsType) ? DEFAULT_ROUND_POINTS : roundToDecimal(DEFAULT_ROUND_POINTS);
 
+export const applyDefaultTotalRoundScore = (roundScore: RoundScore, pointsType: string) => {
+  if (roundScore.roundPlayer) {
+    return roundScore;
+  }
+
+  return {
+    ...roundScore,
+    totalRoundScore: getDefaultRoundPoints(pointsType),
+  };
+};
+
 export const getLimitOfRoundPoints = (pointsType: string) =>
   isMicropointsMode(pointsType)
     ? LIMIT_OF_ROUND_POINTS

--- a/packages/utils/tests/gameUtils/gameScoreHelpers.test.ts
+++ b/packages/utils/tests/gameUtils/gameScoreHelpers.test.ts
@@ -220,6 +220,60 @@ describe("gameScoreHelpers", () => {
       expect(mockSetGameOverflowCount).not.toHaveBeenCalled();
     });
 
+    it("should not declare a winner in points mode when total score is below 101", () => {
+      const mockCalculatedRoundScore: RoundScore = {
+        id: 1,
+        playersScores: [
+          {
+            ...mockPlayersScores[0],
+            totalScore: 34,
+          },
+          ...mockPlayersScores.slice(1).map((ps) => ({ ...ps, totalScore: 5 })),
+        ],
+        teamsScores: mockTeamsScores,
+        totalRoundScore: 16,
+        roundPlayer: mockPlayers[0],
+      };
+
+      expect(
+        checkForGameWinner(
+          GameMode.classic,
+          mockPlayers,
+          mockTeams,
+          mockCalculatedRoundScore,
+          0,
+          mockSetGameOverflowCount,
+        ),
+      ).toBeNull();
+    });
+
+    it("should declare a winner in points mode when total score reaches 101", () => {
+      const mockCalculatedRoundScore: RoundScore = {
+        id: 1,
+        playersScores: [
+          {
+            ...mockPlayersScores[0],
+            totalScore: WIN_POINTS,
+          },
+          ...mockPlayersScores.slice(1),
+        ],
+        teamsScores: mockTeamsScores,
+        totalRoundScore: 16,
+        roundPlayer: mockPlayers[0],
+      };
+
+      expect(
+        checkForGameWinner(
+          GameMode.classic,
+          mockPlayers,
+          mockTeams,
+          mockCalculatedRoundScore,
+          0,
+          mockSetGameOverflowCount,
+        ),
+      ).toEqual(mockPlayers[0]);
+    });
+
     it("should return null if game mode is classic and there is no winner", () => {
       const mockCalculatedRoundScore: RoundScore = {
         id: 1,

--- a/packages/utils/tests/gameUtils/prepareStates.test.ts
+++ b/packages/utils/tests/gameUtils/prepareStates.test.ts
@@ -18,6 +18,7 @@ import {
   preparePreviousRoundScoreRow,
   prepareRoundScoresBasedOnGameMode,
   prepareTeams,
+  repairRoundScoreScores,
 } from "../../src/gameUtils/prepareStates";
 
 describe("prepareStates", () => {
@@ -166,6 +167,47 @@ describe("prepareStates", () => {
       };
 
       expect(prepareEmptyRoundScoreRow(state).teamsScores).toEqual([]);
+    });
+
+    it("derives team scores from players when teams are missing (teams mode)", () => {
+      const state = {
+        ...mockRoundSlice,
+        mode: GameMode.teams,
+        players: mockPlayers,
+        roundsScores: [] as RoundScore[],
+      };
+
+      expect(prepareEmptyRoundScoreRow(state).teamsScores).toEqual([
+        { id: 0, teamId: 0, score: 0, boltCount: 0, totalScore: 0 },
+        { id: 1, teamId: 1, score: 0, boltCount: 0, totalScore: 0 },
+      ]);
+    });
+  });
+
+  describe("repairRoundScoreScores", () => {
+    it("fills missing team scores for a pending round", () => {
+      const roundsScores: RoundScore[] = [
+        baseRoundScore({
+          id: 0,
+          teamsScores: [
+            baseTeamScore({ id: 0, teamId: 0, totalScore: 40 }),
+            baseTeamScore({ id: 1, teamId: 1, totalScore: 30 }),
+          ],
+          totalRoundScore: DEFAULT_ROUND_POINTS,
+        }),
+        baseRoundScore({ id: 1, teamsScores: [], totalRoundScore: DEFAULT_ROUND_POINTS }),
+      ];
+
+      const repaired = repairRoundScoreScores(roundsScores[1], {
+        mode: GameMode.teams,
+        players: mockPlayers,
+        roundsScores,
+      });
+
+      expect(repaired.teamsScores).toEqual([
+        { id: 0, teamId: 0, score: 0, boltCount: 0, totalScore: 40 },
+        { id: 1, teamId: 1, score: 0, boltCount: 0, totalScore: 30 },
+      ]);
     });
   });
 

--- a/packages/utils/tests/gameUtils/scoreCalculationHelpers.test.ts
+++ b/packages/utils/tests/gameUtils/scoreCalculationHelpers.test.ts
@@ -1,4 +1,4 @@
-import { LIMIT_OF_ROUND_POINTS } from "@belot/constants";
+import { LIMIT_OF_ROUND_POINTS, POINTS_TYPE } from "@belot/constants";
 import { GameMode, type Player, type RoundScore } from "@belot/types";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -57,6 +57,24 @@ describe("scoreCalculationHelpers", () => {
       expect(result.totalRoundScore).toBe(16);
       expect(result.teamsScores).toHaveLength(2);
     });
+
+    it("keeps point totals unchanged in points mode", () => {
+      const roundScore: RoundScore = baseRoundScore({
+        id: 0,
+        playersScores: mockPlayersScores,
+        teamsScores: mockTeamsScores,
+        totalRoundScore: 16,
+      });
+
+      const result = calculateRoundScore(
+        roundScore,
+        roundPlayer,
+        GameMode.classic,
+        POINTS_TYPE[1].id,
+      );
+
+      expect(result.totalRoundScore).toBe(16);
+    });
   });
 
   describe("calculateTotalRoundScore", () => {
@@ -89,6 +107,16 @@ describe("scoreCalculationHelpers", () => {
         totalRoundScore: LIMIT_OF_ROUND_POINTS.negative,
       });
       expect(result.totalRoundScore).toBe(LIMIT_OF_ROUND_POINTS.negative);
+    });
+
+    it("uses point limits when points type is points", () => {
+      const pointsPrev: RoundScore = baseRoundScore({
+        id: 0,
+        totalRoundScore: 10,
+      });
+
+      const result = calculateTotalRoundScore("+", 50, pointsPrev, POINTS_TYPE[1].id);
+      expect(result.totalRoundScore).toBe(57);
     });
   });
 

--- a/packages/utils/tests/pointsTypeHelpers.test.ts
+++ b/packages/utils/tests/pointsTypeHelpers.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { NEXT_WINNING_STEP, WIN_POINTS } from "@belot/constants";
 
 import {
+  applyDefaultTotalRoundScore,
   formatTotalRoundScoreForDisplay,
   formatRoundPointPresetForDisplay,
   getDefaultRoundPoints,
@@ -36,6 +37,38 @@ describe("pointsTypeHelpers", () => {
 
     it("returns 16 for points", () => {
       expect(getDefaultRoundPoints(POINTS_TYPE[1].id)).toBe(16);
+    });
+  });
+
+  describe("applyDefaultTotalRoundScore", () => {
+    it("applies the default total for pending rounds", () => {
+      expect(
+        applyDefaultTotalRoundScore(
+          {
+            id: 0,
+            roundPlayer: null,
+            totalRoundScore: 162,
+            playersScores: [],
+            teamsScores: [],
+          },
+          POINTS_TYPE[1].id,
+        ),
+      ).toMatchObject({ totalRoundScore: 16 });
+    });
+
+    it("keeps completed rounds unchanged", () => {
+      expect(
+        applyDefaultTotalRoundScore(
+          {
+            id: 0,
+            roundPlayer: { id: 0, name: "A" },
+            totalRoundScore: 162,
+            playersScores: [],
+            teamsScores: [],
+          },
+          POINTS_TYPE[1].id,
+        ),
+      ).toMatchObject({ totalRoundScore: 162 });
     });
   });
 

--- a/packages/utils/tests/pointsTypeHelpers.test.ts
+++ b/packages/utils/tests/pointsTypeHelpers.test.ts
@@ -2,14 +2,20 @@ import { LIMIT_OF_ROUND_POINTS, POINTS_TYPE } from "@belot/constants";
 
 import { describe, expect, it } from "vitest";
 
+import { NEXT_WINNING_STEP, WIN_POINTS } from "@belot/constants";
+
 import {
   formatTotalRoundScoreForDisplay,
+  formatRoundPointPresetForDisplay,
   getDefaultRoundPoints,
   getLimitOfRoundPoints,
+  getNextWinningStep,
   getRoundPointsPresets,
   getScoreInputMaxLength,
+  getWinPoints,
   isMicropointsMode,
   normalizeSkippedRoundScore,
+  convertRoundScoreForPointsType,
 } from "../src/pointsTypeHelpers";
 
 describe("pointsTypeHelpers", () => {
@@ -56,6 +62,30 @@ describe("pointsTypeHelpers", () => {
     });
   });
 
+  describe("formatRoundPointPresetForDisplay", () => {
+    it("shows decimal labels for micropoint preset values", () => {
+      expect(formatRoundPointPresetForDisplay(20, POINTS_TYPE[0].id)).toBe(2);
+      expect(formatRoundPointPresetForDisplay(100, POINTS_TYPE[0].id)).toBe(10);
+    });
+
+    it("shows point preset values as-is in points mode", () => {
+      expect(formatRoundPointPresetForDisplay(2, POINTS_TYPE[1].id)).toBe(2);
+      expect(formatRoundPointPresetForDisplay(10, POINTS_TYPE[1].id)).toBe(10);
+    });
+  });
+
+  describe("getWinPoints", () => {
+    it("returns 101 regardless of points type", () => {
+      expect(getWinPoints()).toBe(WIN_POINTS);
+    });
+  });
+
+  describe("getNextWinningStep", () => {
+    it("returns 50 regardless of points type", () => {
+      expect(getNextWinningStep()).toBe(NEXT_WINNING_STEP);
+    });
+  });
+
   describe("getScoreInputMaxLength", () => {
     it("returns 3 for micropoints", () => {
       expect(getScoreInputMaxLength(POINTS_TYPE[0].id)).toBe(3);
@@ -83,6 +113,46 @@ describe("pointsTypeHelpers", () => {
 
     it("keeps point values unchanged when skipping a round", () => {
       expect(normalizeSkippedRoundScore(16, POINTS_TYPE[1].id)).toBe(16);
+    });
+  });
+
+  describe("convertRoundScoreForPointsType", () => {
+    it("converts micropoint round scores to points", () => {
+      expect(
+        convertRoundScoreForPointsType(
+          {
+            id: 0,
+            roundPlayer: null,
+            totalRoundScore: 162,
+            playersScores: [{ id: 0, playerId: 0, score: 50, boltCount: 0, totalScore: 0 }],
+            teamsScores: [],
+          },
+          POINTS_TYPE[0].id,
+          POINTS_TYPE[1].id,
+        ),
+      ).toMatchObject({
+        totalRoundScore: 16,
+        playersScores: [{ score: 5 }],
+      });
+    });
+
+    it("converts point round scores to micropoints", () => {
+      expect(
+        convertRoundScoreForPointsType(
+          {
+            id: 0,
+            roundPlayer: null,
+            totalRoundScore: 16,
+            playersScores: [{ id: 0, playerId: 0, score: 5, boltCount: 0, totalScore: 0 }],
+            teamsScores: [],
+          },
+          POINTS_TYPE[1].id,
+          POINTS_TYPE[0].id,
+        ),
+      ).toMatchObject({
+        totalRoundScore: 162,
+        playersScores: [{ score: 50 }],
+      });
     });
   });
 });

--- a/packages/utils/tests/pointsTypeHelpers.test.ts
+++ b/packages/utils/tests/pointsTypeHelpers.test.ts
@@ -1,6 +1,6 @@
 import { LIMIT_OF_ROUND_POINTS, POINTS_TYPE } from "@belot/constants";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { NEXT_WINNING_STEP, WIN_POINTS } from "@belot/constants";
 
@@ -16,6 +16,7 @@ import {
   getWinPoints,
   isMicropointsMode,
   normalizeSkippedRoundScore,
+  parseStoredPointsType,
   convertRoundScoreForPointsType,
 } from "../src/pointsTypeHelpers";
 
@@ -186,6 +187,32 @@ describe("pointsTypeHelpers", () => {
         totalRoundScore: 162,
         playersScores: [{ score: 50 }],
       });
+    });
+  });
+
+  describe("parseStoredPointsType", () => {
+    it("returns the stored points type when valid", () => {
+      expect(
+        parseStoredPointsType(JSON.stringify({ pointsType: POINTS_TYPE[1].id })),
+      ).toBe(POINTS_TYPE[1].id);
+    });
+
+    it("returns null and warns when points type is invalid", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      expect(parseStoredPointsType(JSON.stringify({ pointsType: "invalid" }))).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("returns null and logs when settings JSON is malformed", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      expect(parseStoredPointsType("{not-json")).toBeNull();
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/utils/tests/pointsTypeHelpers.test.ts
+++ b/packages/utils/tests/pointsTypeHelpers.test.ts
@@ -1,0 +1,88 @@
+import { LIMIT_OF_ROUND_POINTS, POINTS_TYPE } from "@belot/constants";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatTotalRoundScoreForDisplay,
+  getDefaultRoundPoints,
+  getLimitOfRoundPoints,
+  getRoundPointsPresets,
+  getScoreInputMaxLength,
+  isMicropointsMode,
+  normalizeSkippedRoundScore,
+} from "../src/pointsTypeHelpers";
+
+describe("pointsTypeHelpers", () => {
+  describe("isMicropointsMode", () => {
+    it("returns true for micropoints type", () => {
+      expect(isMicropointsMode(POINTS_TYPE[0].id)).toBe(true);
+    });
+
+    it("returns false for points type", () => {
+      expect(isMicropointsMode(POINTS_TYPE[1].id)).toBe(false);
+    });
+  });
+
+  describe("getDefaultRoundPoints", () => {
+    it("returns 162 for micropoints", () => {
+      expect(getDefaultRoundPoints(POINTS_TYPE[0].id)).toBe(162);
+    });
+
+    it("returns 16 for points", () => {
+      expect(getDefaultRoundPoints(POINTS_TYPE[1].id)).toBe(16);
+    });
+  });
+
+  describe("getLimitOfRoundPoints", () => {
+    it("returns micropoint limits for micropoints mode", () => {
+      expect(getLimitOfRoundPoints(POINTS_TYPE[0].id)).toEqual(LIMIT_OF_ROUND_POINTS);
+    });
+
+    it("returns point limits for points mode", () => {
+      expect(getLimitOfRoundPoints(POINTS_TYPE[1].id)).toEqual({
+        positive: 57,
+        negative: 16,
+      });
+    });
+  });
+
+  describe("getRoundPointsPresets", () => {
+    it("returns micropoint presets for micropoints mode", () => {
+      expect(getRoundPointsPresets(POINTS_TYPE[0].id)).toEqual([20, 50, 100, 150, 200]);
+    });
+
+    it("returns point presets for points mode", () => {
+      expect(getRoundPointsPresets(POINTS_TYPE[1].id)).toEqual([2, 5, 10, 15, 20]);
+    });
+  });
+
+  describe("getScoreInputMaxLength", () => {
+    it("returns 3 for micropoints", () => {
+      expect(getScoreInputMaxLength(POINTS_TYPE[0].id)).toBe(3);
+    });
+
+    it("returns 2 for points", () => {
+      expect(getScoreInputMaxLength(POINTS_TYPE[1].id)).toBe(2);
+    });
+  });
+
+  describe("formatTotalRoundScoreForDisplay", () => {
+    it("converts three-digit micropoint values for display", () => {
+      expect(formatTotalRoundScoreForDisplay(162, POINTS_TYPE[0].id)).toBe(16);
+    });
+
+    it("returns point values as-is in points mode", () => {
+      expect(formatTotalRoundScoreForDisplay(16, POINTS_TYPE[1].id)).toBe(16);
+    });
+  });
+
+  describe("normalizeSkippedRoundScore", () => {
+    it("rounds micropoint values when skipping a round", () => {
+      expect(normalizeSkippedRoundScore(162, POINTS_TYPE[0].id)).toBe(16);
+    });
+
+    it("keeps point values unchanged when skipping a round", () => {
+      expect(normalizeSkippedRoundScore(16, POINTS_TYPE[1].id)).toBe(16);
+    });
+  });
+});


### PR DESCRIPTION
- Added `pointsType` state management using `useGameStore` in various components including `PointCells`, `PlayerScoreInput`, and `RoundScoreSelect`.
- Enhanced score formatting and input handling based on the selected points type, ensuring consistent behavior for micropoints and standard scoring modes.
- Introduced utility functions for points type management in `pointsTypeHelpers`, including score normalization and display formatting.
- Updated relevant tests to accommodate changes in points type handling.