### PR TITLE
refactor: remove unnecessary Vitest environment declarations

### DIFF
--- a/apps/mobile/tests/app/_layout.test.tsx
+++ b/apps/mobile/tests/app/_layout.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { THEMES } from "@belot/constants";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/app/game-table.test.tsx
+++ b/apps/mobile/tests/app/game-table.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/app/players-selection.test.tsx
+++ b/apps/mobile/tests/app/players-selection.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/app/settings-screen.test.tsx
+++ b/apps/mobile/tests/app/settings-screen.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/app/starting-screen.test.tsx
+++ b/apps/mobile/tests/app/starting-screen.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/backButton.test.tsx
+++ b/apps/mobile/tests/components/backButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useRouter } from "expo-router";
 
 import { BackButton } from "@/components/backButton";

--- a/apps/mobile/tests/components/confirmationDialog.test.tsx
+++ b/apps/mobile/tests/components/confirmationDialog.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import ConfirmationDialog from "@/components/confirmationDialog";

--- a/apps/mobile/tests/components/dismissKeyboardView.test.tsx
+++ b/apps/mobile/tests/components/dismissKeyboardView.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { Keyboard } from "react-native";
 
 import DismissKeyboardView from "@/components/dismissKeyboardView";

--- a/apps/mobile/tests/components/extendedTooltip.test.tsx
+++ b/apps/mobile/tests/components/extendedTooltip.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import ExtendedTooltip from "@/components/extendedTooltip";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/extendedTooltipInteractions.test.tsx
+++ b/apps/mobile/tests/components/extendedTooltipInteractions.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/featureToggles/FeatureToggleProvider.test.tsx
+++ b/apps/mobile/tests/components/featureToggles/FeatureToggleProvider.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/game-table/currentDealer.test.tsx
+++ b/apps/mobile/tests/components/game-table/currentDealer.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/game-table/gameTable.test.tsx
+++ b/apps/mobile/tests/components/game-table/gameTable.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode, type RoundScore } from "@belot/types";
 
 import GameTable from "@/components/game-table";

--- a/apps/mobile/tests/components/game-table/header.test.tsx
+++ b/apps/mobile/tests/components/game-table/header.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { AppState } from "react-native";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/game-table/headerInteractions.test.tsx
+++ b/apps/mobile/tests/components/game-table/headerInteractions.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import type { Player, RoundScore } from "@belot/types";
 import { GameMode } from "@belot/types";
 

--- a/apps/mobile/tests/components/game-table/nextRoundButtonIndex.test.tsx
+++ b/apps/mobile/tests/components/game-table/nextRoundButtonIndex.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { type Player, type Team } from "@belot/types";

--- a/apps/mobile/tests/components/game-table/playerScoreInput.test.tsx
+++ b/apps/mobile/tests/components/game-table/playerScoreInput.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import PlayerScoreInput from "@/components/game-table/action-buttons/next-round-button/playerScoreInput";

--- a/apps/mobile/tests/components/game-table/playerScoreInputTeam.test.tsx
+++ b/apps/mobile/tests/components/game-table/playerScoreInputTeam.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import PlayerScoreInput from "@/components/game-table/action-buttons/next-round-button/playerScoreInput";

--- a/apps/mobile/tests/components/game-table/pointCells.test.tsx
+++ b/apps/mobile/tests/components/game-table/pointCells.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode, type RoundScore } from "@belot/types";
 
 import PointCells from "@/components/game-table/pointCells";

--- a/apps/mobile/tests/components/game-table/pointCellsBranches.test.tsx
+++ b/apps/mobile/tests/components/game-table/pointCellsBranches.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode, type RoundScore } from "@belot/types";
 
 import PointCells from "@/components/game-table/pointCells";

--- a/apps/mobile/tests/components/game-table/skipRound.test.tsx
+++ b/apps/mobile/tests/components/game-table/skipRound.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import ConfirmationDialog from "@/components/confirmationDialog";

--- a/apps/mobile/tests/components/game-table/winDialog.test.tsx
+++ b/apps/mobile/tests/components/game-table/winDialog.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/apps/mobile/tests/components/game-table/winDialogInteractions.test.tsx
+++ b/apps/mobile/tests/components/game-table/winDialogInteractions.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/game-table/winDialogReset.test.tsx
+++ b/apps/mobile/tests/components/game-table/winDialogReset.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/navigation.test.tsx
+++ b/apps/mobile/tests/components/navigation.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/pageHeader.test.tsx
+++ b/apps/mobile/tests/components/pageHeader.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { PageHeader } from "@/components/pageHeader";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/players-selection/actionButtonsSubmit.test.tsx
+++ b/apps/mobile/tests/components/players-selection/actionButtonsSubmit.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { ToastAndroid } from "react-native";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/players-selection/inputErrors.test.tsx
+++ b/apps/mobile/tests/components/players-selection/inputErrors.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/players-selection/playersNames.test.tsx
+++ b/apps/mobile/tests/components/players-selection/playersNames.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/players-selection/playersNamesInput.test.tsx
+++ b/apps/mobile/tests/components/players-selection/playersNamesInput.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/components/players-selection/playersSelection.test.tsx
+++ b/apps/mobile/tests/components/players-selection/playersSelection.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { PLAYERS_COUNT } from "@belot/constants";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/components/settings/pointsTypeRadioButton.test.tsx
+++ b/apps/mobile/tests/components/settings/pointsTypeRadioButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { POINTS_TYPE } from "@belot/constants";
 
 import { fireEvent, render, screen } from "@testing-library/react";

--- a/apps/mobile/tests/hooks/game-table/useGetPlayersNamesWithScoreColumn.test.ts
+++ b/apps/mobile/tests/hooks/game-table/useGetPlayersNamesWithScoreColumn.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/mobile/tests/hooks/useKeyboardAvoidView.test.ts
+++ b/apps/mobile/tests/hooks/useKeyboardAvoidView.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { type EmitterSubscription, Keyboard } from "react-native";
 
 import { useKeyboardAvoidView } from "@/hooks/useKeyboardAvoidView";

--- a/apps/mobile/tests/hooks/useKeyboardAvoidViewCleanup.test.ts
+++ b/apps/mobile/tests/hooks/useKeyboardAvoidViewCleanup.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { type EmitterSubscription, Keyboard } from "react-native";
 
 import { useKeyboardAvoidView } from "@/hooks/useKeyboardAvoidView";

--- a/apps/mobile/tests/hooks/usePreventBackPress.test.ts
+++ b/apps/mobile/tests/hooks/usePreventBackPress.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { BackHandler } from "react-native";
 
 import { usePreventBackPress } from "@/hooks/usePreventBackPress";

--- a/apps/mobile/tests/hooks/usePreventBackPressCleanup.test.ts
+++ b/apps/mobile/tests/hooks/usePreventBackPressCleanup.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { BackHandler } from "react-native";
 
 import { usePreventBackPress } from "@/hooks/usePreventBackPress";

--- a/apps/mobile/tests/hooks/useReadInitialTheme.test.ts
+++ b/apps/mobile/tests/hooks/useReadInitialTheme.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useColorScheme } from "react-native";
 
 import { StorageKeys, THEMES } from "@belot/constants";

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -15,6 +15,7 @@ export default mergeConfig(
       jsx: "automatic",
     },
     test: {
+      environment: "jsdom",
       name: "@belot/mobile",
       setupFiles: ["./tests/setup.ts"],
       coverage: {

--- a/apps/web/tests/App.test.tsx
+++ b/apps/web/tests/App.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import App from "@/App";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/_layout.test.tsx
+++ b/apps/web/tests/components/_layout.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { Layout } from "@/components/_layout";
 
 import { render } from "@testing-library/react";

--- a/apps/web/tests/components/backButton.test.tsx
+++ b/apps/web/tests/components/backButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { MemoryRouter } from "react-router-dom";
 
 import { BackButton } from "@/components/backButton";

--- a/apps/web/tests/components/confirmationDialog.test.tsx
+++ b/apps/web/tests/components/confirmationDialog.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import ConfirmationDialog from "@/components/confirmationDialog";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/featureToggles/FeatureToggleProvider.test.tsx
+++ b/apps/web/tests/components/featureToggles/FeatureToggleProvider.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/index.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/index.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { type Player } from "@belot/types";
 
 import NextRoundButton from "@/components/game-table/action-buttons/next-round-button";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInput.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInput.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { GameMode, type RoundScore, type Team } from "@belot/types";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.teams.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { GameMode, type RoundScore } from "@belot/types";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/playerScoreInputWrapper.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { GameMode, type Player, type RoundScore } from "@belot/types";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/roundPlayerDisplay.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/roundPlayerDisplay.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import RoundPlayerDisplay from "@/components/game-table/action-buttons/next-round-button/roundPlayerDisplay";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/roundPlayerSelect.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/roundPlayerSelect.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import RoundPlayerSelect from "@/components/game-table/action-buttons/next-round-button/roundPlayerSelect";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/roundScoreSelect.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/roundScoreSelect.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { type RoundScore } from "@belot/types";

--- a/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/next-round-button/scoreDialogContent.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useState } from "react";
 
 import { type Player, type RoundScore } from "@belot/types";

--- a/apps/web/tests/components/game-table/action-buttons/redoRound.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/redoRound.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import RedoRoundButton from "@/components/game-table/action-buttons/redoRound";
 
 import { screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/action-buttons/resetGame.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/resetGame.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { MemoryRouter } from "react-router-dom";
 
 import ResetGameButton from "@/components/game-table/action-buttons/resetGame";

--- a/apps/web/tests/components/game-table/action-buttons/skipRound.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/skipRound.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import SkipRoundButton from "@/components/game-table/action-buttons/skipRound";
 
 import { screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/action-buttons/undoRound.test.tsx
+++ b/apps/web/tests/components/game-table/action-buttons/undoRound.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import UndoRoundButton from "@/components/game-table/action-buttons/undoRound";
 
 import { screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/header.test.tsx
+++ b/apps/web/tests/components/game-table/header.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { MemoryRouter } from "react-router-dom";
 
 import Header from "@/components/game-table/header";

--- a/apps/web/tests/components/game-table/index.test.tsx
+++ b/apps/web/tests/components/game-table/index.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import GameTable from "@/components/game-table";
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/pointCells.test.tsx
+++ b/apps/web/tests/components/game-table/pointCells.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import PointCells from "@/components/game-table/pointCells";

--- a/apps/web/tests/components/game-table/tableBodyWrapper.test.tsx
+++ b/apps/web/tests/components/game-table/tableBodyWrapper.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { GameMode } from "@belot/types";
 
 import TableBodyWrapper from "@/components/game-table/tableBodyWrapper";

--- a/apps/web/tests/components/game-table/tableHeaderWrapper.test.tsx
+++ b/apps/web/tests/components/game-table/tableHeaderWrapper.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import TableHeaderWrapper from "@/components/game-table/tableHeaderWrapper";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/game-table/winDialog.test.tsx
+++ b/apps/web/tests/components/game-table/winDialog.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { MemoryRouter } from "react-router-dom";
 
 import WinDialog from "@/components/game-table/winDialog";

--- a/apps/web/tests/components/pageHeader.test.tsx
+++ b/apps/web/tests/components/pageHeader.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { PageHeader } from "@/components/pageHeader";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/phoneScreen.test.tsx
+++ b/apps/web/tests/components/phoneScreen.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import PhoneScreen from "@/components/phoneScreen";
 
 import { render } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/actionButtons.test.tsx
+++ b/apps/web/tests/components/players-selection/actionButtons.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import ActionButtons from "@/components/players-selection/actionButtons";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/dealerSelectDialogContent.test.tsx
+++ b/apps/web/tests/components/players-selection/dealerSelectDialogContent.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import DealerSelectDialogContent from "@/components/players-selection/dealerSelectDialogContent";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/inputErrors.test.tsx
+++ b/apps/web/tests/components/players-selection/inputErrors.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { EmptyNameError, RepeatingNamesError } from "@/components/players-selection/inputErrors";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/loadPreviousGameButton.test.tsx
+++ b/apps/web/tests/components/players-selection/loadPreviousGameButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import LoadPreviousGameButton from "@/components/players-selection/loadPreviousGameButton";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/maxScoreSelector.test.tsx
+++ b/apps/web/tests/components/players-selection/maxScoreSelector.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import MaxScoreSelector from "@/components/players-selection/maxScoreSelector";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/playersCount.test.tsx
+++ b/apps/web/tests/components/players-selection/playersCount.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import PlayersCount from "@/components/players-selection/playersCount";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/playersNames.test.tsx
+++ b/apps/web/tests/components/players-selection/playersNames.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { THEMES } from "@belot/constants";
 
 import PlayersNames from "@/components/players-selection/playersNames";

--- a/apps/web/tests/components/players-selection/playersNamesInput.test.tsx
+++ b/apps/web/tests/components/players-selection/playersNamesInput.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import PlayersNamesInput from "@/components/players-selection/playersNamesInput";
 
 import { fireEvent, render } from "@testing-library/react";

--- a/apps/web/tests/components/players-selection/playersRandomizer.test.tsx
+++ b/apps/web/tests/components/players-selection/playersRandomizer.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import PlayersRandomizer from "@/components/players-selection/playersRandomizer";
 
 import { screen } from "@testing-library/react";

--- a/apps/web/tests/components/settings/pointsTypeRadioButton.test.tsx
+++ b/apps/web/tests/components/settings/pointsTypeRadioButton.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { POINTS_TYPE } from "@belot/constants";
 
 import { PointsTypeRadioButton } from "@/components/settings/pointsTypeRadioButton";

--- a/apps/web/tests/helpers/isMobile.test.ts
+++ b/apps/web/tests/helpers/isMobile.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { isMobile } from "@/helpers/isMobile";
 
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/apps/web/tests/helpers/localization.test.ts
+++ b/apps/web/tests/helpers/localization.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { getDeviceLanguage } from "@/helpers/localization";
 
 import { afterEach, describe, expect, it, vi } from "vitest";

--- a/apps/web/tests/helpers/storageHelpers.test.ts
+++ b/apps/web/tests/helpers/storageHelpers.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { StorageKeys } from "@belot/constants";
 
 import {

--- a/apps/web/tests/helpers/subscribeToVisibilityChange.test.ts
+++ b/apps/web/tests/helpers/subscribeToVisibilityChange.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { subscribeToVisibilityChange } from "@/helpers/subscribeToVisibilityChange";
 
 import { describe, expect, it, vi } from "vitest";

--- a/apps/web/tests/helpers/themeHelpers.test.ts
+++ b/apps/web/tests/helpers/themeHelpers.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { StorageKeys, THEMES } from "@belot/constants";
 
 import { readInitialTheme } from "@/helpers/themeHelpers";

--- a/apps/web/tests/hooks/game-table/useAutoScrollTableBody.test.ts
+++ b/apps/web/tests/hooks/game-table/useAutoScrollTableBody.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { createRef } from "react";
 
 import useAutoScrollTableBody from "@/hooks/game-table/useAutoScrollTableBody";

--- a/apps/web/tests/hooks/game-table/useGetPlayersNamesWithScoreColumn.test.ts
+++ b/apps/web/tests/hooks/game-table/useGetPlayersNamesWithScoreColumn.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import useGetPlayersNamesWithScoreColumn from "@/hooks/game-table/useGetPlayersNamesWithScoreColumn";
 
 import { renderHook } from "@testing-library/react";

--- a/apps/web/tests/hooks/starting-screen/useStartingScreenActions.test.ts
+++ b/apps/web/tests/hooks/starting-screen/useStartingScreenActions.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { useStartingScreenActions } from "@/hooks/starting-screen/useStartingScreenActions";
 
 import { renderHook } from "@testing-library/react";

--- a/apps/web/tests/hooks/usePreventBackPress.test.ts
+++ b/apps/web/tests/hooks/usePreventBackPress.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { type BlockerFunction, NavigationType } from "react-router-dom";
 
 import { usePreventBackPress } from "@/hooks/usePreventBackPress";

--- a/apps/web/tests/pages/game-table.test.tsx
+++ b/apps/web/tests/pages/game-table.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import GameTablePage from "@/pages/game-table";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/pages/players-selection.test.tsx
+++ b/apps/web/tests/pages/players-selection.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import PlayersSelectionPage from "@/pages/players-selection";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/apps/web/tests/pages/settings.test.tsx
+++ b/apps/web/tests/pages/settings.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import SettingsPage from "@/pages/settings";
 
 import { cleanup, render, screen } from "@testing-library/react";

--- a/apps/web/tests/pages/starting-page.test.tsx
+++ b/apps/web/tests/pages/starting-page.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import StartingPage from "@/pages/starting-page";
 
 import { render, screen } from "@testing-library/react";

--- a/apps/web/tests/routes/router.test.tsx
+++ b/apps/web/tests/routes/router.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { Suspense } from "react";
 
 import { RouterProvider } from "react-router-dom";

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,7 @@ export default mergeConfig(
   mergeConfig(viteConfig, shared),
   defineConfig({
     test: {
+      environment: "jsdom",
       name: "@belot/web",
       setupFiles: ["./tests/setup.ts"],
       coverage: {

--- a/packages/components/tests/currentDealer.test.tsx
+++ b/packages/components/tests/currentDealer.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/components/tests/playersNamesInputWrapper.test.tsx
+++ b/packages/components/tests/playersNamesInputWrapper.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/components/tests/playersSelectionContextProvider.test.tsx
+++ b/packages/components/tests/playersSelectionContextProvider.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { usePlayersSelectionContext } from "@belot/hooks";
 
 import { render, screen } from "@testing-library/react";

--- a/packages/components/tests/playersTable.test.tsx
+++ b/packages/components/tests/playersTable.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 

--- a/packages/components/tests/themeContextProvider.test.tsx
+++ b/packages/components/tests/themeContextProvider.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { THEMES } from "@belot/constants";
 import { useThemeContext } from "@belot/hooks";
 

--- a/packages/components/tests/timeTracker.test.tsx
+++ b/packages/components/tests/timeTracker.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   shared,
   defineProject({
     test: {
+      environment: "jsdom",
       name: "@belot/components",
     },
   }),


### PR DESCRIPTION
Remove unnecessary Vitest environment declarations from test files and set the environment to jsdom in configuration files for both mobile and web applications.