### PR TITLE
feat: add dev tools page with feature toggles and authentication

### DIFF
--- a/apps/mobile/app/dev-tools.tsx
+++ b/apps/mobile/app/dev-tools.tsx
@@ -1,0 +1,82 @@
+import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
+import { useDevTools } from "@belot/hooks";
+import { formatLocalizationString } from "@belot/localizations";
+
+import { BackButton } from "@/components/backButton";
+import { PageHeader } from "@/components/pageHeader";
+import { Button, ButtonText } from "@/components/ui/button";
+import { HStack } from "@/components/ui/hstack";
+import { Input, InputField } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Text } from "@/components/ui/text";
+import { VStack } from "@/components/ui/vstack";
+
+import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
+
+const FEATURE_TOGGLE_NAMES = Object.keys(FEATURE_TOGGLES) as FeatureToggleName[];
+
+export default function DevToolsScreen() {
+  const {
+    auth,
+    handleSubmit,
+    isLocked,
+    messages,
+    password,
+    setFeatureToggle,
+    setPassword,
+    toggles,
+  } = useDevTools({ getFromStorage, setToStorage });
+
+  return (
+    <VStack className="relative w-full flex-1">
+      <BackButton />
+      <PageHeader title={messages.devToolsTitle} />
+
+      <VStack className="flex-1 justify-center gap-3 px-6 pt-20">
+        {auth.isAuthenticated ? (
+          FEATURE_TOGGLE_NAMES.map((name) => (
+            <HStack
+              key={name}
+              className="min-h-14 items-center justify-between gap-3 rounded-lg border border-background-300 bg-background-100 px-3 py-2"
+            >
+              <Text className="text-sm">{name}</Text>
+              <Switch
+                value={toggles[name]}
+                onToggle={(enabled) => void setFeatureToggle(name, enabled)}
+                accessibilityLabel={formatLocalizationString(messages.devToolsFeatureToggleLabel, [
+                  name,
+                ])}
+                trackColor={{ false: "#d4d4d4", true: "#525252" }}
+                thumbColor="#fafafa"
+                ios_backgroundColor="#d4d4d4"
+                size="md"
+              />
+            </HStack>
+          ))
+        ) : (
+          <VStack className="gap-3">
+            <VStack className="gap-2">
+              <Text>{messages.devToolsPasswordLabel}</Text>
+              <Input isDisabled={isLocked}>
+                <InputField
+                  value={password}
+                  onChangeText={setPassword}
+                  secureTextEntry
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                />
+              </Input>
+            </VStack>
+            {auth.error ? <Text className="text-error-700">{auth.error}</Text> : null}
+            {isLocked ? (
+              <Text className="text-typography-500">{messages.devToolsTryAgainIn}</Text>
+            ) : null}
+            <Button onPress={handleSubmit} isDisabled={isLocked || password.length === 0}>
+              <ButtonText>{messages.devToolsUnlockButton}</ButtonText>
+            </Button>
+          </VStack>
+        )}
+      </VStack>
+    </VStack>
+  );
+}

--- a/apps/mobile/app/starting-screen.tsx
+++ b/apps/mobile/app/starting-screen.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
-import { Image, View } from "react-native";
+import { Image, Pressable, View } from "react-native";
 
-import { useNavigation } from "expo-router";
+import { useNavigation, useRouter } from "expo-router";
 
 import { useGameStore } from "@belot/store";
 
@@ -14,6 +14,7 @@ import { useStartingScreenActions } from "@/hooks/starting-screen/useStartingScr
 
 export default function StartingScreen() {
   const navigation = useNavigation();
+  const router = useRouter();
   const pendingReset = useGameStore((state) => state.pendingReset);
   const reset = useGameStore((state) => state.reset);
 
@@ -29,15 +30,21 @@ export default function StartingScreen() {
 
   return (
     <View className="flex-1 items-center justify-center">
-      <VStack className="absolute top-10 items-center justify-center gap-3">
-        <Image
-          source={require("../assets/images/ic_launcher_no_bg.png")}
-          style={{ width: 100, height: 100 }}
-        />
-        <Heading size="4xl" className="text-center font-normal">
-          Belot-score
-        </Heading>
-      </VStack>
+      <Pressable
+        className="absolute top-10"
+        onLongPress={() => void router.push("/dev-tools")}
+        delayLongPress={1200}
+      >
+        <VStack className="items-center justify-center gap-3">
+          <Image
+            source={require("../assets/images/ic_launcher_no_bg.png")}
+            style={{ width: 100, height: 100 }}
+          />
+          <Heading size="4xl" className="text-center font-normal">
+            Belot-score
+          </Heading>
+        </VStack>
+      </Pressable>
       <VStack className="gap-3">
         {actions.map((action) => (
           <Button key={action.index} onPress={action.onPress} action="primary" variant="solid">

--- a/apps/mobile/components/ui/switch/index.tsx
+++ b/apps/mobile/components/ui/switch/index.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React from "react";
+
+import { Switch as RNSwitch } from "react-native";
+
+import { createSwitch } from "@gluestack-ui/core/switch/creator";
+import { tva, withStyleContext } from "@gluestack-ui/utils/nativewind-utils";
+import type { VariantProps } from "@gluestack-ui/utils/nativewind-utils";
+
+const UISwitch = createSwitch({
+  Root: withStyleContext(RNSwitch),
+});
+
+const switchStyle = tva({
+  base: "data-[focus=true]:outline-0 data-[focus=true]:ring-2 data-[focus=true]:ring-indicator-primary web:cursor-pointer disabled:cursor-not-allowed data-[disabled=true]:opacity-40 data-[invalid=true]:border-error-700 data-[invalid=true]:rounded-xl data-[invalid=true]:border-2",
+
+  variants: {
+    size: {
+      sm: "scale-75",
+      md: "",
+      lg: "scale-125",
+    },
+  },
+});
+
+type ISwitchProps = React.ComponentProps<typeof UISwitch> & VariantProps<typeof switchStyle>;
+const Switch = React.forwardRef<React.ComponentRef<typeof UISwitch>, ISwitchProps>(function Switch(
+  { className, size = "md", ...props },
+  ref,
+) {
+  return <UISwitch ref={ref} {...props} className={switchStyle({ size, class: className })} />;
+});
+
+Switch.displayName = "Switch";
+export { Switch };

--- a/apps/mobile/tests/app/dev-tools.test.tsx
+++ b/apps/mobile/tests/app/dev-tools.test.tsx
@@ -1,0 +1,127 @@
+import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+interface AuthMock {
+  status: string;
+  isAuthenticated: boolean;
+  failedAttempts: number;
+  blockedUntil: number | null;
+  remainingBlockMs: number;
+  error: string | null;
+  submitPassword: Mock<(password: string) => void>;
+}
+
+const mocks = vi.hoisted(() => ({
+  auth: {
+    status: "unlocked",
+    isAuthenticated: false,
+    failedAttempts: 0,
+    blockedUntil: null,
+    remainingBlockMs: 0,
+    error: null as string | null,
+    submitPassword: vi.fn<(password: string) => void>(),
+  } as AuthMock,
+  password: "123321",
+  toggles: {} as Record<FeatureToggleName, boolean>,
+  setPassword: vi.fn(),
+  setFeatureToggle: vi.fn(),
+}));
+
+vi.mock("@belot/hooks", () => ({
+  useDevTools: () => ({
+    auth: mocks.auth,
+    handleSubmit: () => {
+      mocks.auth.submitPassword(mocks.password);
+      mocks.setPassword("");
+    },
+    isLocked: mocks.auth.status === "locked",
+    messages: {
+      devToolsFeatureToggleLabel: "{0} feature toggle",
+      devToolsPasswordLabel: "Password",
+      devToolsTitle: "Dev tools",
+      devToolsTryAgainIn: "Try again in 2:05.",
+      devToolsUnlockButton: "Unlock",
+    },
+    password: mocks.password,
+    setPassword: mocks.setPassword,
+    toggles: mocks.toggles,
+    setFeatureToggle: mocks.setFeatureToggle,
+  }),
+}));
+
+vi.mock("@belot/localizations", () => ({
+  formatLocalizationString: (localization: string, args: string[] = []) =>
+    localization.replace(/{(\d+)}/g, (match, index: number) => args[index] ?? match),
+}));
+
+describe("DevToolsScreen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth = {
+      status: "unlocked",
+      isAuthenticated: false,
+      failedAttempts: 0,
+      blockedUntil: null,
+      remainingBlockMs: 0,
+      error: null,
+      submitPassword: vi.fn<(password: string) => void>(),
+    };
+    mocks.password = "123321";
+    mocks.toggles = { ...FEATURE_TOGGLES };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("asks for a password before showing feature toggles", async () => {
+    const { default: DevToolsScreen } = await import("@/app/dev-tools");
+    const { container } = render(<DevToolsScreen />);
+
+    const passwordInput = container.querySelector("input");
+    expect(passwordInput).toBeTruthy();
+
+    fireEvent.change(passwordInput!, { target: { value: "123321" } });
+    fireEvent.click(screen.getByRole("button", { name: "Unlock" }));
+
+    expect(mocks.auth.submitPassword).toHaveBeenCalledWith("123321");
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+
+  it("shows lock countdown and disables submit when locked", async () => {
+    mocks.auth.status = "locked";
+    mocks.auth.error = "Too many incorrect attempts. Try again in 5 minutes.";
+    mocks.auth.remainingBlockMs = 125_000;
+
+    const { default: DevToolsScreen } = await import("@/app/dev-tools");
+    render(<DevToolsScreen />);
+
+    expect(screen.getByText("Try again in 2:05.")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Unlock" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("renders toggles and persists changes after authentication", async () => {
+    mocks.auth.isAuthenticated = true;
+    mocks.toggles = {
+      ...FEATURE_TOGGLES,
+      "settings-screen": true,
+    };
+
+    const { default: DevToolsScreen } = await import("@/app/dev-tools");
+    render(<DevToolsScreen />);
+
+    const settingsSwitch = screen.getByRole("switch", {
+      name: "settings-screen feature toggle",
+    }) as HTMLInputElement;
+    expect(settingsSwitch.checked).toBe(true);
+
+    fireEvent.click(settingsSwitch);
+
+    expect(mocks.setFeatureToggle).toHaveBeenCalledWith("settings-screen", false);
+  });
+});

--- a/apps/mobile/tests/app/starting-screen.test.tsx
+++ b/apps/mobile/tests/app/starting-screen.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
 
 vi.mock("expo-router", () => ({
   useNavigation: () => ({ addListener: vi.fn(() => vi.fn()) }),
+  useRouter: () => ({ push: mocks.push }),
 }));
 
 vi.mock("@belot/store", () => ({
@@ -18,6 +23,11 @@ vi.mock("@/hooks/starting-screen/useStartingScreenActions", () => ({
 }));
 
 describe("StartingScreen", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
   it("renders title and action buttons", async () => {
     const { default: StartingScreen } = await import("@/app/starting-screen");
     render(<StartingScreen />);
@@ -25,5 +35,15 @@ describe("StartingScreen", () => {
     expect(screen.getByText("Belot-score")).toBeTruthy();
     expect(screen.getByText("New game")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("opens dev tools from the hidden brand long press", async () => {
+    const { fireEvent } = await import("@testing-library/react");
+    const { default: StartingScreen } = await import("@/app/starting-screen");
+    render(<StartingScreen />);
+
+    fireEvent.doubleClick(screen.getByText("Belot-score"));
+
+    expect(mocks.push).toHaveBeenCalledWith("/dev-tools");
   });
 });

--- a/apps/mobile/tests/setup.ts
+++ b/apps/mobile/tests/setup.ts
@@ -68,16 +68,17 @@ function omitUiProps(props: Record<string, unknown>) {
 
 const createElement = (
   tag: string,
-  { children, onPress, onChangeText, ...props }: Record<string, unknown> = {},
+  { children, onPress, onLongPress, onChangeText, ...props }: Record<string, unknown> = {},
 ) => {
   const domProps = omitUiProps(props);
 
-  if (onPress || domProps.onClick) {
+  if (onPress || onLongPress || domProps.onClick) {
     return React.createElement(
       "button",
       {
         type: "button",
         onClick: onPress ?? domProps.onClick,
+        onDoubleClick: onLongPress,
         ...domProps,
       },
       children as React.ReactNode,
@@ -93,6 +94,22 @@ const createElement = (
 
   return React.createElement(tag, domProps, children as React.ReactNode);
 };
+
+interface MockScrollViewHandle {
+  scrollToEnd: ReturnType<typeof vi.fn>;
+  scrollTo: ReturnType<typeof vi.fn>;
+}
+
+const MockScrollView = React.forwardRef<MockScrollViewHandle, Record<string, unknown>>(
+  function MockScrollView(props, ref) {
+    React.useImperativeHandle(ref, () => ({
+      scrollToEnd: vi.fn(),
+      scrollTo: vi.fn(),
+    }));
+
+    return React.createElement("div", omitUiProps(props));
+  },
+);
 
 vi.mock("react-native", () => {
   const listeners: Record<string, ((e?: unknown) => void)[]> = {};
@@ -111,13 +128,7 @@ vi.mock("react-native", () => {
     View: (props: Record<string, unknown>) => createElement("div", props),
     Text: (props: Record<string, unknown>) => createElement("span", props),
     Image: (props: Record<string, unknown>) => createElement("img", props),
-    ScrollView: React.forwardRef((props: Record<string, unknown>, ref) => {
-      React.useImperativeHandle(ref, () => ({
-        scrollToEnd: vi.fn(),
-        scrollTo: vi.fn(),
-      }));
-      return React.createElement("div", { ref, ...omitUiProps(props) });
-    }),
+    ScrollView: MockScrollView,
     TouchableWithoutFeedback: ({ onPress, ...props }: Record<string, unknown>) =>
       createElement("div", { onPress, ...props }),
     Keyboard: {
@@ -156,6 +167,19 @@ vi.mock("react-native", () => {
     },
     ActivityIndicator: (props: Record<string, unknown>) => createElement("div", props),
     Pressable: (props: Record<string, unknown>) => createElement("button", props),
+    Switch: ({ value, onValueChange, accessibilityLabel, ...props }: Record<string, unknown>) =>
+      React.createElement("input", {
+        type: "checkbox",
+        role: "switch",
+        checked: Boolean(value),
+        "aria-label": accessibilityLabel,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+          if (typeof onValueChange === "function") {
+            onValueChange(event.target.checked);
+          }
+        },
+        ...omitUiProps(props),
+      }),
     StyleSheet: { create: (styles: unknown) => styles },
   };
 });
@@ -216,11 +240,17 @@ const mockUi = (name: string) => {
   return Component;
 };
 
-const buttonMock = ({ children, onPress, disabled, ...props }: Record<string, unknown>) =>
+const buttonMock = ({
+  children,
+  onPress,
+  disabled,
+  isDisabled,
+  ...props
+}: Record<string, unknown>) =>
   createElement("button", {
     type: "button",
-    onClick: disabled ? undefined : onPress,
-    disabled,
+    onClick: disabled || isDisabled ? undefined : onPress,
+    disabled: Boolean(disabled || isDisabled),
     ...omitUiProps(props),
     children,
   });

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,22 +2,13 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": [],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "paths": {
-      "@/*": [
-        "./*"
-      ],
-      "tailwind.config": [
-        "./tailwind.config.js"
-      ]
+      "@/*": ["./*"],
+      "tailwind.config": ["./tailwind.config.js"]
     }
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    ".expo/types/**/*.ts",
-    "expo-env.d.ts",
-    "nativewind-env.d.ts"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "nativewind-env.d.ts"]
 }

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-all outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background pointer-events-none block size-4 rounded-full shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/apps/web/src/pages/dev-tools.tsx
+++ b/apps/web/src/pages/dev-tools.tsx
@@ -1,0 +1,82 @@
+import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
+import { useDevTools } from "@belot/hooks";
+import { formatLocalizationString } from "@belot/localizations";
+
+import { BackButton } from "@/components/backButton";
+import { PageHeader } from "@/components/pageHeader";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
+
+const FEATURE_TOGGLE_NAMES = Object.keys(FEATURE_TOGGLES) as FeatureToggleName[];
+
+export default function DevToolsPage() {
+  const {
+    auth,
+    handleSubmit,
+    isLocked,
+    messages,
+    password,
+    setFeatureToggle,
+    setPassword,
+    toggles,
+  } = useDevTools({ getFromStorage, setToStorage });
+
+  return (
+    <div className="relative flex h-full flex-col items-center">
+      <BackButton />
+      <PageHeader title={messages.devToolsTitle} />
+
+      <div className="flex w-full flex-1 flex-col justify-center px-6 pt-20">
+        {auth.isAuthenticated ? (
+          <div className="flex flex-col gap-3">
+            {FEATURE_TOGGLE_NAMES.map((name) => (
+              <div
+                key={name}
+                className="border-border bg-input/20 flex min-h-14 items-center justify-between gap-3 rounded-lg border px-3 py-2"
+              >
+                <Label htmlFor={`feature-toggle-${name}`} className="text-sm">
+                  {name}
+                </Label>
+                <Switch
+                  id={`feature-toggle-${name}`}
+                  checked={toggles[name]}
+                  onCheckedChange={(enabled) => void setFeatureToggle(name, enabled)}
+                  aria-label={formatLocalizationString(messages.devToolsFeatureToggleLabel, [name])}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="dev-tools-password">{messages.devToolsPasswordLabel}</Label>
+              <Input
+                id="dev-tools-password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                disabled={isLocked}
+                autoComplete="current-password"
+              />
+            </div>
+            {auth.error ? <p className="text-destructive text-sm">{auth.error}</p> : null}
+            {isLocked ? (
+              <p className="text-muted-foreground text-sm">{messages.devToolsTryAgainIn}</p>
+            ) : null}
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isLocked || password.length === 0}
+            >
+              {messages.devToolsUnlockButton}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/router.tsx
+++ b/apps/web/src/routes/router.tsx
@@ -5,6 +5,7 @@ import { createBrowserRouter } from "react-router-dom";
 import App from "@/App";
 
 const GameTablePage = lazy(() => import("@/pages/game-table"));
+const DevToolsPage = lazy(() => import("@/pages/dev-tools"));
 const PlayersSelectionPage = lazy(() => import("@/pages/players-selection"));
 const SettingsPage = lazy(() => import("@/pages/settings"));
 const StartingPage = lazy(() => import("@/pages/starting-page"));
@@ -29,6 +30,10 @@ export const router = createBrowserRouter([
       {
         path: "/settings",
         element: <SettingsPage />,
+      },
+      {
+        path: "/dev-tools",
+        element: <DevToolsPage />,
       },
     ],
   },

--- a/apps/web/tests/pages/dev-tools.test.tsx
+++ b/apps/web/tests/pages/dev-tools.test.tsx
@@ -1,0 +1,114 @@
+import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
+
+import DevToolsPage from "@/pages/dev-tools";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: {
+    status: "unlocked",
+    isAuthenticated: false,
+    failedAttempts: 0,
+    blockedUntil: null,
+    remainingBlockMs: 0,
+    error: null as string | null,
+    submitPassword: vi.fn<(password: string) => void>(),
+  },
+  password: "123321",
+  toggles: {} as Record<FeatureToggleName, boolean>,
+  setPassword: vi.fn(),
+  setFeatureToggle: vi.fn(),
+}));
+
+vi.mock("@belot/hooks", () => ({
+  useDevTools: () => ({
+    auth: mocks.auth,
+    handleSubmit: () => {
+      mocks.auth.submitPassword(mocks.password);
+      mocks.setPassword("");
+    },
+    isLocked: mocks.auth.status === "locked",
+    messages: {
+      devToolsFeatureToggleLabel: "{0} feature toggle",
+      devToolsPasswordLabel: "Password",
+      devToolsTitle: "Dev tools",
+      devToolsTryAgainIn: "Try again in 2:05.",
+      devToolsUnlockButton: "Unlock",
+    },
+    password: mocks.password,
+    setPassword: mocks.setPassword,
+    toggles: mocks.toggles,
+    setFeatureToggle: mocks.setFeatureToggle,
+  }),
+}));
+
+vi.mock("@belot/localizations", () => ({
+  formatLocalizationString: (localization: string, args: string[] = []) =>
+    localization.replace(/{(\d+)}/g, (match, index: number) => args[index] ?? match),
+}));
+
+vi.mock("@/components/backButton", () => ({
+  BackButton: () => <button type="button">Back</button>,
+}));
+
+describe("DevToolsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth = {
+      status: "unlocked",
+      isAuthenticated: false,
+      failedAttempts: 0,
+      blockedUntil: null,
+      remainingBlockMs: 0,
+      error: null,
+      submitPassword: vi.fn<(password: string) => void>(),
+    };
+    mocks.password = "123321";
+    mocks.toggles = { ...FEATURE_TOGGLES };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("asks for a password before showing feature toggles", () => {
+    render(<DevToolsPage />);
+
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "123321" } });
+    fireEvent.click(screen.getByRole("button", { name: "Unlock" }));
+
+    expect(mocks.auth.submitPassword).toHaveBeenCalledWith("123321");
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+
+  it("shows lock countdown and disables submit when locked", () => {
+    mocks.auth.status = "locked";
+    mocks.auth.error = "Too many incorrect attempts. Try again in 5 minutes.";
+    mocks.auth.remainingBlockMs = 125_000;
+
+    render(<DevToolsPage />);
+
+    expect(screen.getByText("Try again in 2:05.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Unlock" })).toHaveProperty("disabled", true);
+  });
+
+  it("renders toggles and persists changes after authentication", () => {
+    mocks.auth.isAuthenticated = true;
+    mocks.toggles = {
+      ...FEATURE_TOGGLES,
+      "settings-screen": true,
+    };
+
+    render(<DevToolsPage />);
+
+    const settingsSwitch = screen.getByRole("switch", {
+      name: "settings-screen feature toggle",
+    });
+    expect(settingsSwitch.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.click(settingsSwitch);
+
+    expect(mocks.setFeatureToggle).toHaveBeenCalledWith("settings-screen", false);
+  });
+});

--- a/apps/web/tests/routes/router.test.tsx
+++ b/apps/web/tests/routes/router.test.tsx
@@ -8,6 +8,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/App", () => ({ default: () => null }));
+vi.mock("@/pages/dev-tools", () => ({ default: () => null }));
 vi.mock("@/pages/game-table", () => ({ default: () => null }));
 vi.mock("@/pages/players-selection", () => ({ default: () => null }));
 vi.mock("@/pages/settings", () => ({ default: () => null }));
@@ -19,10 +20,16 @@ describe("router", () => {
 
     const rootRoute = router.routes[0];
     expect(rootRoute?.path).toBe("/");
-    expect(rootRoute?.children).toHaveLength(4);
+    expect(rootRoute?.children).toHaveLength(5);
 
     const paths = rootRoute?.children?.map((route) => route.path ?? "index");
-    expect(paths).toEqual(["index", "/players-selection", "/game-table", "/settings"]);
+    expect(paths).toEqual([
+      "index",
+      "/players-selection",
+      "/game-table",
+      "/settings",
+      "/dev-tools",
+    ]);
   });
 
   it("creates a browser router instance", () => {

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": [],
     "module": "ESNext",
     "skipLibCheck": true,
     "paths": {

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -8,6 +8,7 @@
     "verbatimModuleSyntax": true,
     "noEmit": true,
     "lib": ["ES2022", "DOM"],
+    "types": [],
     "jsx": "react-jsx"
   },
   "include": ["src/**/*.tsx", "src/**/*.ts", "tests/**/*.ts", "tests/**/*.tsx", "vitest.config.ts"]

--- a/packages/constants/src/storageKeys.ts
+++ b/packages/constants/src/storageKeys.ts
@@ -7,4 +7,6 @@ export enum StorageKeys {
   settings = "settings",
   featureToggles = "featureToggles",
   maxScore = "maxScore",
+  devToolsFailedAttempts = "devToolsFailedAttempts",
+  devToolsBlockedAt = "devToolsBlockedAt",
 }

--- a/packages/hooks/src/featureToggles/FeatureToggleProvider.tsx
+++ b/packages/hooks/src/featureToggles/FeatureToggleProvider.tsx
@@ -1,10 +1,13 @@
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+
+import { type FeatureToggleName, StorageKeys } from "@belot/constants";
 
 import { useSyncPointsTypeFeature } from "../usePointsTypeFeature";
 import {
   type FeatureToggleState,
   areFeatureToggleStatesEqual,
   getDefaultFeatureToggleState,
+  serializeFeatureToggleState,
   syncFeatureTogglesToStorage,
 } from "./featureToggleUtils";
 import { FeatureToggleContext } from "./toggleContext";
@@ -25,6 +28,27 @@ export const FeatureToggleProvider = ({
   setToStorage,
 }: FeatureToggleProviderProps) => {
   const [toggles, setToggles] = useState<FeatureToggleState>(getDefaultFeatureToggleState);
+
+  const setFeatureToggle = useCallback(
+    async (name: FeatureToggleName, enabled: boolean) => {
+      const nextToggles = {
+        ...toggles,
+        [name]: enabled,
+      };
+
+      setToggles(nextToggles);
+      await setToStorage(StorageKeys.featureToggles, serializeFeatureToggleState(nextToggles));
+    },
+    [setToStorage, toggles],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      toggles,
+      setFeatureToggle,
+    }),
+    [setFeatureToggle, toggles],
+  );
 
   useEffect(() => {
     let isCancelled = false;
@@ -50,7 +74,7 @@ export const FeatureToggleProvider = ({
   }, [getFromStorage, setToStorage]);
 
   return (
-    <FeatureToggleContext.Provider value={toggles}>
+    <FeatureToggleContext.Provider value={contextValue}>
       <PointsTypeFeatureSync />
       {children}
     </FeatureToggleContext.Provider>

--- a/packages/hooks/src/featureToggles/toggleContext.ts
+++ b/packages/hooks/src/featureToggles/toggleContext.ts
@@ -1,7 +1,17 @@
 import { createContext } from "react";
 
+import type { FeatureToggleName } from "@belot/constants";
+
 import { type FeatureToggleState, getDefaultFeatureToggleState } from "./featureToggleUtils";
 
-export const FeatureToggleContext = createContext<FeatureToggleState>(
-  getDefaultFeatureToggleState(),
-);
+export interface FeatureToggleContextValue {
+  toggles: FeatureToggleState;
+  setFeatureToggle: (name: FeatureToggleName, enabled: boolean) => Promise<void>;
+}
+
+const noopSetFeatureToggle: FeatureToggleContextValue["setFeatureToggle"] = () => Promise.resolve();
+
+export const FeatureToggleContext = createContext<FeatureToggleContextValue>({
+  toggles: getDefaultFeatureToggleState(),
+  setFeatureToggle: noopSetFeatureToggle,
+});

--- a/packages/hooks/src/featureToggles/useFeatureToggle.ts
+++ b/packages/hooks/src/featureToggles/useFeatureToggle.ts
@@ -4,7 +4,7 @@ import { isKnownFeatureToggle, logUnknownFeatureToggle } from "./featureToggleUt
 import { FeatureToggleContext } from "./toggleContext";
 
 export const useFeatureToggle = (name: string): boolean => {
-  const toggles = useContext(FeatureToggleContext);
+  const { toggles } = useContext(FeatureToggleContext);
 
   if (!isKnownFeatureToggle(name)) {
     logUnknownFeatureToggle(name);
@@ -13,3 +13,5 @@ export const useFeatureToggle = (name: string): boolean => {
 
   return toggles[name] ?? false;
 };
+
+export const useFeatureToggles = () => useContext(FeatureToggleContext);

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -22,4 +22,6 @@ export * from "./useSettings";
 export * from "./usePointsTypeFeature";
 export * from "./usePointsTypeSelection";
 export * from "./useMaxScoreSelection";
+export * from "./useDevTools";
+export * from "./useDevToolsAuth";
 export * from "./featureToggles";

--- a/packages/hooks/src/useDevTools.ts
+++ b/packages/hooks/src/useDevTools.ts
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+import { useLocalizations } from "@belot/localizations";
+import { formatRemainingTime } from "@belot/utils";
+
+import type { FeatureToggleStorage } from "./featureToggles/types";
+import { useFeatureToggles } from "./featureToggles/useFeatureToggle";
+import { useDevToolsAuth } from "./useDevToolsAuth";
+
+export const useDevTools = ({ getFromStorage, setToStorage }: FeatureToggleStorage) => {
+  const [password, setPassword] = useState("");
+
+  const { toggles, setFeatureToggle } = useFeatureToggles();
+
+  const auth = useDevToolsAuth({ getFromStorage, setToStorage });
+  const isLocked = auth.status === "locked";
+
+  const messages = useLocalizations([
+    { key: "dev.tools.title" },
+    { key: "dev.tools.password.label" },
+    { key: "dev.tools.unlock.button" },
+    { key: "dev.tools.feature.toggle.label" },
+    { key: "dev.tools.try.again.in", args: [formatRemainingTime(auth.remainingBlockMs)] },
+  ]);
+
+  const handleSubmit = () => {
+    void auth.submitPassword(password);
+    setPassword("");
+  };
+
+  return {
+    auth,
+    handleSubmit,
+    isLocked,
+    messages,
+    password,
+    setFeatureToggle,
+    setPassword,
+    toggles,
+  };
+};

--- a/packages/hooks/src/useDevToolsAuth.ts
+++ b/packages/hooks/src/useDevToolsAuth.ts
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { StorageKeys } from "@belot/constants";
+import { useLocalizations } from "@belot/localizations";
+import {
+  DEV_TOOLS_BLOCK_DURATION_MS,
+  getDevToolsRemainingBlockMs,
+  getNextDevToolsFailedAttemptState,
+  isDevToolsPasswordValid,
+  parseStoredDevToolsNumber,
+} from "@belot/utils";
+
+import type { FeatureToggleStorage } from "./featureToggles/types";
+
+type DevToolsAuthStatus = "locked" | "unlocked";
+
+export interface UseDevToolsAuthResult {
+  status: DevToolsAuthStatus;
+  isAuthenticated: boolean;
+  failedAttempts: number;
+  blockedUntil: number | null;
+  remainingBlockMs: number;
+  error: string | null;
+  submitPassword: (password: string) => Promise<void>;
+}
+
+export const useDevToolsAuth = ({
+  getFromStorage,
+  setToStorage,
+}: FeatureToggleStorage): UseDevToolsAuthResult => {
+  const messages = useLocalizations([
+    { key: "dev.tools.locked.error" },
+    { key: "dev.tools.too.many.attempts.error" },
+    { key: "dev.tools.incorrect.password.error" },
+  ]);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [failedAttempts, setFailedAttempts] = useState(0);
+  const [blockedAt, setBlockedAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [error, setError] = useState<string | null>(null);
+
+  const blockedUntil = blockedAt === null ? null : blockedAt + DEV_TOOLS_BLOCK_DURATION_MS;
+  const remainingBlockMs = getDevToolsRemainingBlockMs(blockedAt, now);
+  const status: DevToolsAuthStatus = remainingBlockMs > 0 ? "locked" : "unlocked";
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const initializeAuthState = async () => {
+      const [storedFailedAttempts, storedBlockedAt] = await Promise.all([
+        getFromStorage(StorageKeys.devToolsFailedAttempts),
+        getFromStorage(StorageKeys.devToolsBlockedAt),
+      ]);
+
+      if (isCancelled) {
+        return;
+      }
+
+      const nextFailedAttempts = parseStoredDevToolsNumber(storedFailedAttempts);
+      const nextBlockedAt = parseStoredDevToolsNumber(storedBlockedAt);
+      const nextNow = Date.now();
+
+      if (nextBlockedAt && nextNow - nextBlockedAt < DEV_TOOLS_BLOCK_DURATION_MS) {
+        setFailedAttempts(nextFailedAttempts);
+        setBlockedAt(nextBlockedAt);
+        setNow(nextNow);
+        return;
+      }
+
+      setFailedAttempts(nextBlockedAt ? 0 : nextFailedAttempts);
+      setBlockedAt(null);
+      setNow(nextNow);
+
+      if (nextBlockedAt) {
+        await Promise.all([
+          setToStorage(StorageKeys.devToolsFailedAttempts, "0"),
+          setToStorage(StorageKeys.devToolsBlockedAt, "0"),
+        ]);
+      }
+    };
+
+    void initializeAuthState();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [getFromStorage, setToStorage]);
+
+  useEffect(() => {
+    if (status !== "locked") {
+      return;
+    }
+
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [status]);
+
+  const submitPassword = useCallback(
+    async (password: string) => {
+      const nextNow = Date.now();
+      setNow(nextNow);
+
+      if (blockedAt !== null && nextNow - blockedAt < DEV_TOOLS_BLOCK_DURATION_MS) {
+        setError(messages.devToolsLockedError);
+        return;
+      }
+
+      if (isDevToolsPasswordValid(password)) {
+        setIsAuthenticated(true);
+        setFailedAttempts(0);
+        setBlockedAt(null);
+        setError(null);
+        await Promise.all([
+          setToStorage(StorageKeys.devToolsFailedAttempts, "0"),
+          setToStorage(StorageKeys.devToolsBlockedAt, "0"),
+        ]);
+        return;
+      }
+
+      const failedAttemptState = getNextDevToolsFailedAttemptState(failedAttempts, nextNow);
+      setFailedAttempts(failedAttemptState.failedAttempts);
+
+      if (failedAttemptState.blockedAt !== null) {
+        setBlockedAt(failedAttemptState.blockedAt);
+        setError(messages.devToolsTooManyAttemptsError);
+        await Promise.all([
+          setToStorage(
+            StorageKeys.devToolsFailedAttempts,
+            String(failedAttemptState.failedAttempts),
+          ),
+          setToStorage(StorageKeys.devToolsBlockedAt, String(failedAttemptState.blockedAt)),
+        ]);
+        return;
+      }
+
+      setError(messages.devToolsIncorrectPasswordError);
+      await setToStorage(
+        StorageKeys.devToolsFailedAttempts,
+        String(failedAttemptState.failedAttempts),
+      );
+    },
+    [
+      blockedAt,
+      failedAttempts,
+      messages.devToolsIncorrectPasswordError,
+      messages.devToolsLockedError,
+      messages.devToolsTooManyAttemptsError,
+      setToStorage,
+    ],
+  );
+
+  return useMemo(
+    () => ({
+      status,
+      isAuthenticated,
+      failedAttempts,
+      blockedUntil,
+      remainingBlockMs,
+      error,
+      submitPassword,
+    }),
+    [
+      blockedUntil,
+      error,
+      failedAttempts,
+      isAuthenticated,
+      remainingBlockMs,
+      status,
+      submitPassword,
+    ],
+  );
+};

--- a/packages/hooks/tests/FeatureToggleProvider.test.ts
+++ b/packages/hooks/tests/FeatureToggleProvider.test.ts
@@ -36,6 +36,8 @@ vi.mock("react", async (importOriginal) => {
   return {
     ...actual,
     useState: () => [mocks.toggles, mocks.setToggles],
+    useCallback: (callback: (...args: unknown[]) => unknown) => callback,
+    useMemo: (factory: () => unknown) => factory(),
     useEffect: (effect: () => void | (() => void)) => {
       mocks.effectCleanups.push(effect());
     },
@@ -61,10 +63,17 @@ describe("FeatureToggleProvider", () => {
       children: "child",
       getFromStorage: mocks.getFromStorage,
       setToStorage: mocks.setToStorage,
-    }) as ReactElement<{ value: FeatureToggleState; children: string }>;
+    }) as ReactElement<{
+      value: {
+        toggles: FeatureToggleState;
+        setFeatureToggle: unknown;
+      };
+      children: string;
+    }>;
 
     expect(element.type).toBe(FeatureToggleContext.Provider);
-    expect(element.props.value).toEqual(FEATURE_TOGGLES);
+    expect(element.props.value.toggles).toEqual(FEATURE_TOGGLES);
+    expect(element.props.value.setFeatureToggle).toEqual(expect.any(Function));
     expect(element.props.children).toEqual(expect.arrayContaining(["child"]));
   });
 
@@ -100,6 +109,39 @@ describe("FeatureToggleProvider", () => {
       ...FEATURE_TOGGLES,
       "settings-screen": true,
     });
+  });
+
+  it("persists and provides feature toggle updates", async () => {
+    const { FeatureToggleProvider } = await import("../src/featureToggles/FeatureToggleProvider");
+    const { StorageKeys } = await import("@belot/constants");
+    const { serializeFeatureToggleState } =
+      await import("../src/featureToggles/featureToggleUtils");
+
+    const element = FeatureToggleProvider({
+      children: "child",
+      getFromStorage: mocks.getFromStorage,
+      setToStorage: mocks.setToStorage,
+    }) as ReactElement<{
+      value: {
+        toggles: FeatureToggleState;
+        setFeatureToggle: (name: "settings-screen", enabled: boolean) => Promise<void>;
+      };
+      children: string;
+    }>;
+
+    await element.props.value.setFeatureToggle("settings-screen", true);
+
+    expect(mocks.setToggles).toHaveBeenCalledWith({
+      ...FEATURE_TOGGLES,
+      "settings-screen": true,
+    });
+    expect(mocks.setToStorage).toHaveBeenCalledWith(
+      StorageKeys.featureToggles,
+      serializeFeatureToggleState({
+        ...FEATURE_TOGGLES,
+        "settings-screen": true,
+      }),
+    );
   });
 
   it("does not update state after unmount when sync resolves late", async () => {

--- a/packages/hooks/tests/useFeatureToggle.test.ts
+++ b/packages/hooks/tests/useFeatureToggle.test.ts
@@ -19,7 +19,10 @@ vi.mock("react", async (importOriginal) => {
 
   return {
     ...actual,
-    useContext: () => mocks.toggles,
+    useContext: () => ({
+      toggles: mocks.toggles,
+      setFeatureToggle: vi.fn(),
+    }),
   };
 });
 
@@ -60,5 +63,12 @@ describe("useFeatureToggle", () => {
     const { useFeatureToggle } = await import("../src/featureToggles/useFeatureToggle");
 
     expect(useFeatureToggle("settings-screen")).toBe(false);
+  });
+
+  it("returns the full context from useFeatureToggles", async () => {
+    const { useFeatureToggles } = await import("../src/featureToggles/useFeatureToggle");
+
+    expect(useFeatureToggles().toggles).toEqual(FEATURE_TOGGLES);
+    expect(useFeatureToggles().setFeatureToggle).toEqual(expect.any(Function));
   });
 });

--- a/packages/localizations/src/en.json
+++ b/packages/localizations/src/en.json
@@ -36,5 +36,13 @@
   "settings.points.type": "Points type",
   "settings.points.type.hint": "When using micropoints, the default game is 162 micropoints, while the default game using points is 16 points.",
   "settings.points.type.micropoints": "Micropoints",
-  "settings.points.type.points": "Points"
+  "settings.points.type.points": "Points",
+  "dev.tools.title": "Dev tools",
+  "dev.tools.password.label": "Password",
+  "dev.tools.unlock.button": "Unlock",
+  "dev.tools.try.again.in": "Try again in {0}.",
+  "dev.tools.feature.toggle.label": "{0} feature toggle",
+  "dev.tools.locked.error": "Dev tools are temporarily locked.",
+  "dev.tools.too.many.attempts.error": "Too many incorrect attempts. Try again in 5 minutes.",
+  "dev.tools.incorrect.password.error": "Incorrect password."
 }

--- a/packages/localizations/src/ro.json
+++ b/packages/localizations/src/ro.json
@@ -36,5 +36,13 @@
   "settings.points.type": "Tipul punctelor",
   "settings.points.type.hint": "Când folosești microbile, jocul implicit este de 162 microbile, în timp ce jocul implicit folosind bile este de 16.",
   "settings.points.type.micropoints": "Microbile",
-  "settings.points.type.points": "Bile"
+  "settings.points.type.points": "Bile",
+  "dev.tools.title": "Instrumente dev",
+  "dev.tools.password.label": "Parolă",
+  "dev.tools.unlock.button": "Deblochează",
+  "dev.tools.try.again.in": "Încearcă din nou peste {0}.",
+  "dev.tools.feature.toggle.label": "Comutator funcționalitate {0}",
+  "dev.tools.locked.error": "Instrumentele dev sunt blocate temporar.",
+  "dev.tools.too.many.attempts.error": "Prea multe încercări incorecte. Încearcă din nou peste 5 minute.",
+  "dev.tools.incorrect.password.error": "Parolă incorectă."
 }

--- a/packages/localizations/src/ru.json
+++ b/packages/localizations/src/ru.json
@@ -36,5 +36,13 @@
   "settings.points.type": "Тип очков",
   "settings.points.type.hint": "При использовании микроочков, стандартная игра - 162 микроочков, в то время как при использовании очков, стандартная игра - 16 очков.",
   "settings.points.type.micropoints": "Микроочки",
-  "settings.points.type.points": "Очки"
+  "settings.points.type.points": "Очки",
+  "dev.tools.title": "Инструменты разработчика",
+  "dev.tools.password.label": "Пароль",
+  "dev.tools.unlock.button": "Разблокировать",
+  "dev.tools.try.again.in": "Попробуйте снова через {0}.",
+  "dev.tools.feature.toggle.label": "Переключатель функции {0}",
+  "dev.tools.locked.error": "Инструменты разработчика временно заблокированы.",
+  "dev.tools.too.many.attempts.error": "Слишком много неверных попыток. Попробуйте снова через 5 минут.",
+  "dev.tools.incorrect.password.error": "Неверный пароль."
 }

--- a/packages/utils/src/devtools/devToolsAuthUtils.ts
+++ b/packages/utils/src/devtools/devToolsAuthUtils.ts
@@ -1,0 +1,38 @@
+export const DEV_TOOLS_PASSWORD = "123321";
+export const MAX_DEV_TOOLS_FAILED_ATTEMPTS = 5;
+export const DEV_TOOLS_BLOCK_DURATION_MS = 5 * 60 * 1000;
+
+export const parseStoredDevToolsNumber = (value: string | null): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+export const getDevToolsRemainingBlockMs = (blockedAt: number | null, now: number): number => {
+  if (blockedAt === null) {
+    return 0;
+  }
+
+  return Math.max(blockedAt + DEV_TOOLS_BLOCK_DURATION_MS - now, 0);
+};
+
+export const isDevToolsPasswordValid = (password: string): boolean =>
+  password === DEV_TOOLS_PASSWORD;
+
+export const getNextDevToolsFailedAttemptState = (
+  failedAttempts: number,
+  now: number,
+): {
+  failedAttempts: number;
+  blockedAt: number | null;
+} => {
+  const nextFailedAttempts = failedAttempts + 1;
+
+  return {
+    failedAttempts: nextFailedAttempts,
+    blockedAt: nextFailedAttempts >= MAX_DEV_TOOLS_FAILED_ATTEMPTS ? now : null,
+  };
+};

--- a/packages/utils/src/devtools/formatRemainingTime.ts
+++ b/packages/utils/src/devtools/formatRemainingTime.ts
@@ -1,0 +1,7 @@
+export const formatRemainingTime = (remainingMs: number) => {
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};

--- a/packages/utils/src/devtools/index.ts
+++ b/packages/utils/src/devtools/index.ts
@@ -1,0 +1,2 @@
+export * from "./formatRemainingTime";
+export * from "./devToolsAuthUtils";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,3 +2,4 @@ export * from "./commonUtils";
 export * from "./playersUtils";
 export * from "./pointsTypeHelpers";
 export * from "./gameUtils";
+export * from "./devtools";

--- a/packages/utils/tests/devtools/devToolsAuthUtils.test.ts
+++ b/packages/utils/tests/devtools/devToolsAuthUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEV_TOOLS_BLOCK_DURATION_MS,
+  getDevToolsRemainingBlockMs,
+  getNextDevToolsFailedAttemptState,
+  isDevToolsPasswordValid,
+  parseStoredDevToolsNumber,
+} from "../../src/devtools/devToolsAuthUtils";
+
+describe("devToolsAuthUtils", () => {
+  it("parses positive stored numbers", () => {
+    expect(parseStoredDevToolsNumber("123")).toBe(123);
+    expect(parseStoredDevToolsNumber(null)).toBe(0);
+    expect(parseStoredDevToolsNumber("invalid")).toBe(0);
+    expect(parseStoredDevToolsNumber("-1")).toBe(0);
+  });
+
+  it("validates the dev tools password", () => {
+    expect(isDevToolsPasswordValid("123321")).toBe(true);
+    expect(isDevToolsPasswordValid("wrong")).toBe(false);
+  });
+
+  it("calculates remaining lock time", () => {
+    const blockedAt = 1_000;
+
+    expect(getDevToolsRemainingBlockMs(blockedAt, 31_000)).toBe(
+      DEV_TOOLS_BLOCK_DURATION_MS - 30_000,
+    );
+    expect(getDevToolsRemainingBlockMs(blockedAt, blockedAt + DEV_TOOLS_BLOCK_DURATION_MS)).toBe(0);
+    expect(getDevToolsRemainingBlockMs(null, 1_000)).toBe(0);
+  });
+
+  it("locks after the fifth failed attempt", () => {
+    expect(getNextDevToolsFailedAttemptState(3, 10_000)).toEqual({
+      failedAttempts: 4,
+      blockedAt: null,
+    });
+    expect(getNextDevToolsFailedAttemptState(4, 10_000)).toEqual({
+      failedAttempts: 5,
+      blockedAt: 10_000,
+    });
+  });
+});


### PR DESCRIPTION
- Implemented a new DevToolsPage that allows toggling features and requires password authentication.
- Added hooks for managing dev tools authentication and feature toggles.
- Created utility functions for handling dev tools password validation and lockout logic.
- Updated localization files to include strings for the new dev tools functionality.
- Enhanced tests for the new features, including password submission and feature toggle persistence.
- Refactored existing components and hooks to support the new dev tools functionality.