### PR TITLE
refactor: split dev tools components

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate dev tools password
+        env:
+          EXPO_PUBLIC_DEV_TOOLS_PASSWORD: ${{ secrets.EXPO_PUBLIC_DEV_TOOLS_PASSWORD }}
+        run: |
+          if [ -z "$EXPO_PUBLIC_DEV_TOOLS_PASSWORD" ]; then
+            echo "Missing required GitHub secret: EXPO_PUBLIC_DEV_TOOLS_PASSWORD" >&2
+            exit 1
+          fi
+
       - name: Bump Android version
         if: github.event_name == 'workflow_dispatch'
         working-directory: apps/mobile
@@ -105,6 +114,7 @@ jobs:
         working-directory: apps/mobile
         env:
           NODE_ENV: production
+          EXPO_PUBLIC_DEV_TOOLS_PASSWORD: ${{ secrets.EXPO_PUBLIC_DEV_TOOLS_PASSWORD }}
         run: node ./scripts/android-gradlew.js assembleRelease
 
       - name: Prepare release artifact

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -46,6 +46,15 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Validate dev tools password
+        env:
+          EXPO_PUBLIC_DEV_TOOLS_PASSWORD: ${{ secrets.EXPO_PUBLIC_DEV_TOOLS_PASSWORD }}
+        run: |
+          if [ -z "$EXPO_PUBLIC_DEV_TOOLS_PASSWORD" ]; then
+            echo "Missing required GitHub secret: EXPO_PUBLIC_DEV_TOOLS_PASSWORD" >&2
+            exit 1
+          fi
+
       - name: Bump Android version
         working-directory: apps/mobile
         run: |
@@ -81,3 +90,4 @@ jobs:
         run: eas build --platform android --profile preview --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EXPO_PUBLIC_DEV_TOOLS_PASSWORD: ${{ secrets.EXPO_PUBLIC_DEV_TOOLS_PASSWORD }}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -43,3 +43,14 @@ adb install -r android/app/build/outputs/apk/release/app-release.apk
 ```
 
 **EAS Build (expo.dev):** From `apps/mobile` run `eas build --platform android --profile preview` (or use the Expo dashboard). The project uses a minimal Metro config compatible with EAS cloud builds.
+
+## Dev tools password
+
+The dev tools screen reads its password from `EXPO_PUBLIC_DEV_TOOLS_PASSWORD` at build time.
+
+For GitHub Actions APK builds, create a repository secret named
+`EXPO_PUBLIC_DEV_TOOLS_PASSWORD`. The Android workflows fail early if this secret is missing.
+
+For EAS cloud builds, also configure `EXPO_PUBLIC_DEV_TOOLS_PASSWORD` in the Expo/EAS project
+environment for the build profile you use, because public Expo variables are bundled into the app
+during the remote build.

--- a/apps/mobile/app/dev-tools.tsx
+++ b/apps/mobile/app/dev-tools.tsx
@@ -1,14 +1,10 @@
 import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
 import { useDevTools } from "@belot/hooks";
-import { formatLocalizationString } from "@belot/localizations";
 
 import { BackButton } from "@/components/backButton";
+import { FeatureToggleList } from "@/components/dev-tools/featureToggleList";
+import { PasswordUnlockForm } from "@/components/dev-tools/passwordUnlockForm";
 import { PageHeader } from "@/components/pageHeader";
-import { Button, ButtonText } from "@/components/ui/button";
-import { HStack } from "@/components/ui/hstack";
-import { Input, InputField } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
-import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
 
 import { getDevToolsPassword } from "@/helpers/devToolsPassword";
@@ -35,47 +31,23 @@ export default function DevToolsScreen() {
 
       <VStack className="flex-1 justify-center gap-3 px-6 pt-20">
         {auth.isAuthenticated ? (
-          FEATURE_TOGGLE_NAMES.map((name) => (
-            <HStack
-              key={name}
-              className="min-h-14 items-center justify-between gap-3 rounded-lg border border-background-300 bg-background-100 px-3 py-2"
-            >
-              <Text className="text-sm">{name}</Text>
-              <Switch
-                value={toggles[name]}
-                onToggle={(enabled) => void setFeatureToggle(name, enabled)}
-                accessibilityLabel={formatLocalizationString(messages.devToolsFeatureToggleLabel, [
-                  name,
-                ])}
-                trackColor={{ false: "#d4d4d4", true: "#525252" }}
-                thumbColor="#fafafa"
-                ios_backgroundColor="#d4d4d4"
-                size="md"
-              />
-            </HStack>
-          ))
+          <FeatureToggleList
+            labelTemplate={messages.devToolsFeatureToggleLabel}
+            names={FEATURE_TOGGLE_NAMES}
+            onToggle={(name, enabled) => void setFeatureToggle(name, enabled)}
+            toggles={toggles}
+          />
         ) : (
-          <VStack className="gap-3">
-            <VStack className="gap-2">
-              <Text>{messages.devToolsPasswordLabel}</Text>
-              <Input isDisabled={isLocked}>
-                <InputField
-                  value={password}
-                  onChangeText={setPassword}
-                  secureTextEntry
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                />
-              </Input>
-            </VStack>
-            {auth.error ? <Text className="text-error-700">{auth.error}</Text> : null}
-            {isLocked ? (
-              <Text className="text-typography-500">{messages.devToolsTryAgainIn}</Text>
-            ) : null}
-            <Button onPress={handleSubmit} isDisabled={isLocked || password.length === 0}>
-              <ButtonText>{messages.devToolsUnlockButton}</ButtonText>
-            </Button>
-          </VStack>
+          <PasswordUnlockForm
+            error={auth.error}
+            isLocked={isLocked}
+            onPasswordChange={setPassword}
+            onSubmit={handleSubmit}
+            password={password}
+            passwordLabel={messages.devToolsPasswordLabel}
+            tryAgainMessage={messages.devToolsTryAgainIn}
+            unlockButtonLabel={messages.devToolsUnlockButton}
+          />
         )}
       </VStack>
     </VStack>

--- a/apps/mobile/components/dev-tools/featureToggleList.tsx
+++ b/apps/mobile/components/dev-tools/featureToggleList.tsx
@@ -1,0 +1,33 @@
+import type { FeatureToggleName } from "@belot/constants";
+
+import { VStack } from "@/components/ui/vstack";
+
+import { FeatureToggleRow } from "./featureToggleRow";
+
+interface FeatureToggleListProps {
+  labelTemplate: string;
+  names: FeatureToggleName[];
+  onToggle: (name: FeatureToggleName, enabled: boolean) => void;
+  toggles: Record<FeatureToggleName, boolean>;
+}
+
+export function FeatureToggleList({
+  labelTemplate,
+  names,
+  onToggle,
+  toggles,
+}: FeatureToggleListProps) {
+  return (
+    <VStack className="gap-3">
+      {names.map((name) => (
+        <FeatureToggleRow
+          key={name}
+          labelTemplate={labelTemplate}
+          name={name}
+          onToggle={onToggle}
+          value={toggles[name]}
+        />
+      ))}
+    </VStack>
+  );
+}

--- a/apps/mobile/components/dev-tools/featureToggleRow.tsx
+++ b/apps/mobile/components/dev-tools/featureToggleRow.tsx
@@ -1,0 +1,30 @@
+import type { FeatureToggleName } from "@belot/constants";
+import { formatLocalizationString } from "@belot/localizations";
+
+import { HStack } from "@/components/ui/hstack";
+import { Switch } from "@/components/ui/switch";
+import { Text } from "@/components/ui/text";
+
+interface FeatureToggleRowProps {
+  labelTemplate: string;
+  name: FeatureToggleName;
+  onToggle: (name: FeatureToggleName, enabled: boolean) => void;
+  value: boolean;
+}
+
+export function FeatureToggleRow({ labelTemplate, name, onToggle, value }: FeatureToggleRowProps) {
+  return (
+    <HStack className="min-h-14 items-center justify-between gap-3 rounded-lg border border-background-300 bg-background-100 px-3 py-2">
+      <Text className="text-sm">{name}</Text>
+      <Switch
+        value={value}
+        onToggle={(enabled) => onToggle(name, enabled)}
+        accessibilityLabel={formatLocalizationString(labelTemplate, [name])}
+        trackColor={{ false: "#d4d4d4", true: "#525252" }}
+        thumbColor="#fafafa"
+        ios_backgroundColor="#d4d4d4"
+        size="md"
+      />
+    </HStack>
+  );
+}

--- a/apps/mobile/components/dev-tools/passwordUnlockForm.tsx
+++ b/apps/mobile/components/dev-tools/passwordUnlockForm.tsx
@@ -1,0 +1,60 @@
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+
+import DismissKeyboardView from "@/components/dismissKeyboardView";
+import { Button, ButtonText } from "@/components/ui/button";
+import { Input, InputField } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { VStack } from "@/components/ui/vstack";
+
+interface PasswordUnlockFormProps {
+  error: string | null;
+  isLocked: boolean;
+  onPasswordChange: (password: string) => void;
+  onSubmit: () => void;
+  password: string;
+  passwordLabel: string;
+  tryAgainMessage: string;
+  unlockButtonLabel: string;
+}
+
+export function PasswordUnlockForm({
+  error,
+  isLocked,
+  onPasswordChange,
+  onSubmit,
+  password,
+  passwordLabel,
+  tryAgainMessage,
+  unlockButtonLabel,
+}: PasswordUnlockFormProps) {
+  return (
+    <KeyboardAwareScrollView
+      className="w-full flex-1 bg-phone-screen-background"
+      contentContainerStyle={{ flexGrow: 1, width: "100%" }}
+      enableOnAndroid
+      keyboardShouldPersistTaps="handled"
+    >
+      <DismissKeyboardView>
+        <VStack className="w-full flex-1 justify-center gap-3">
+          <VStack className="w-full gap-2">
+            <Text>{passwordLabel}</Text>
+            <Input className="w-full" isDisabled={isLocked}>
+              <InputField
+                value={password}
+                onChangeText={onPasswordChange}
+                secureTextEntry
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+            </Input>
+          </VStack>
+          {error ? <Text className="text-error-700">{error}</Text> : null}
+          {isLocked ? <Text className="text-typography-500">{tryAgainMessage}</Text> : null}
+          <Button onPress={onSubmit} isDisabled={isLocked || password.length === 0}>
+            <ButtonText>{unlockButtonLabel}</ButtonText>
+          </Button>
+        </VStack>
+      </DismissKeyboardView>
+    </KeyboardAwareScrollView>
+  );
+}

--- a/apps/web/src/components/dev-tools/featureToggleList.tsx
+++ b/apps/web/src/components/dev-tools/featureToggleList.tsx
@@ -1,0 +1,31 @@
+import type { FeatureToggleName } from "@belot/constants";
+
+import { FeatureToggleRow } from "./featureToggleRow";
+
+interface FeatureToggleListProps {
+  labelTemplate: string;
+  names: FeatureToggleName[];
+  onToggle: (name: FeatureToggleName, enabled: boolean) => void;
+  toggles: Record<FeatureToggleName, boolean>;
+}
+
+export function FeatureToggleList({
+  labelTemplate,
+  names,
+  onToggle,
+  toggles,
+}: FeatureToggleListProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {names.map((name) => (
+        <FeatureToggleRow
+          key={name}
+          labelTemplate={labelTemplate}
+          name={name}
+          onToggle={onToggle}
+          value={toggles[name]}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/dev-tools/featureToggleRow.tsx
+++ b/apps/web/src/components/dev-tools/featureToggleRow.tsx
@@ -1,0 +1,30 @@
+import type { FeatureToggleName } from "@belot/constants";
+import { formatLocalizationString } from "@belot/localizations";
+
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface FeatureToggleRowProps {
+  labelTemplate: string;
+  name: FeatureToggleName;
+  onToggle: (name: FeatureToggleName, enabled: boolean) => void;
+  value: boolean;
+}
+
+export function FeatureToggleRow({ labelTemplate, name, onToggle, value }: FeatureToggleRowProps) {
+  const id = `feature-toggle-${name}`;
+
+  return (
+    <div className="border-border bg-input/20 flex min-h-14 items-center justify-between gap-3 rounded-lg border px-3 py-2">
+      <Label htmlFor={id} className="text-sm">
+        {name}
+      </Label>
+      <Switch
+        id={id}
+        checked={value}
+        onCheckedChange={(enabled) => onToggle(name, enabled)}
+        aria-label={formatLocalizationString(labelTemplate, [name])}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/dev-tools/passwordUnlockForm.tsx
+++ b/apps/web/src/components/dev-tools/passwordUnlockForm.tsx
@@ -1,0 +1,46 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface PasswordUnlockFormProps {
+  error: string | null;
+  isLocked: boolean;
+  onPasswordChange: (password: string) => void;
+  onSubmit: () => void;
+  password: string;
+  passwordLabel: string;
+  tryAgainMessage: string;
+  unlockButtonLabel: string;
+}
+
+export function PasswordUnlockForm({
+  error,
+  isLocked,
+  onPasswordChange,
+  onSubmit,
+  password,
+  passwordLabel,
+  tryAgainMessage,
+  unlockButtonLabel,
+}: PasswordUnlockFormProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="dev-tools-password">{passwordLabel}</Label>
+        <Input
+          id="dev-tools-password"
+          type="password"
+          value={password}
+          onChange={(event) => onPasswordChange(event.target.value)}
+          disabled={isLocked}
+          autoComplete="current-password"
+        />
+      </div>
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+      {isLocked ? <p className="text-muted-foreground text-sm">{tryAgainMessage}</p> : null}
+      <Button type="button" onClick={onSubmit} disabled={isLocked || password.length === 0}>
+        {unlockButtonLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/dev-tools.tsx
+++ b/apps/web/src/pages/dev-tools.tsx
@@ -1,13 +1,10 @@
 import { FEATURE_TOGGLES, type FeatureToggleName } from "@belot/constants";
 import { useDevTools } from "@belot/hooks";
-import { formatLocalizationString } from "@belot/localizations";
 
 import { BackButton } from "@/components/backButton";
+import { FeatureToggleList } from "@/components/dev-tools/featureToggleList";
+import { PasswordUnlockForm } from "@/components/dev-tools/passwordUnlockForm";
 import { PageHeader } from "@/components/pageHeader";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 
 import { getDevToolsPassword } from "@/helpers/devToolsPassword";
 import { getFromStorage, setToStorage } from "@/helpers/storageHelpers";
@@ -33,49 +30,23 @@ export default function DevToolsPage() {
 
       <div className="flex w-full flex-1 flex-col justify-center px-6 pt-20">
         {auth.isAuthenticated ? (
-          <div className="flex flex-col gap-3">
-            {FEATURE_TOGGLE_NAMES.map((name) => (
-              <div
-                key={name}
-                className="border-border bg-input/20 flex min-h-14 items-center justify-between gap-3 rounded-lg border px-3 py-2"
-              >
-                <Label htmlFor={`feature-toggle-${name}`} className="text-sm">
-                  {name}
-                </Label>
-                <Switch
-                  id={`feature-toggle-${name}`}
-                  checked={toggles[name]}
-                  onCheckedChange={(enabled) => void setFeatureToggle(name, enabled)}
-                  aria-label={formatLocalizationString(messages.devToolsFeatureToggleLabel, [name])}
-                />
-              </div>
-            ))}
-          </div>
+          <FeatureToggleList
+            labelTemplate={messages.devToolsFeatureToggleLabel}
+            names={FEATURE_TOGGLE_NAMES}
+            onToggle={(name, enabled) => void setFeatureToggle(name, enabled)}
+            toggles={toggles}
+          />
         ) : (
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="dev-tools-password">{messages.devToolsPasswordLabel}</Label>
-              <Input
-                id="dev-tools-password"
-                type="password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                disabled={isLocked}
-                autoComplete="current-password"
-              />
-            </div>
-            {auth.error ? <p className="text-destructive text-sm">{auth.error}</p> : null}
-            {isLocked ? (
-              <p className="text-muted-foreground text-sm">{messages.devToolsTryAgainIn}</p>
-            ) : null}
-            <Button
-              type="button"
-              onClick={handleSubmit}
-              disabled={isLocked || password.length === 0}
-            >
-              {messages.devToolsUnlockButton}
-            </Button>
-          </div>
+          <PasswordUnlockForm
+            error={auth.error}
+            isLocked={isLocked}
+            onPasswordChange={setPassword}
+            onSubmit={handleSubmit}
+            password={password}
+            passwordLabel={messages.devToolsPasswordLabel}
+            tryAgainMessage={messages.devToolsTryAgainIn}
+            unlockButtonLabel={messages.devToolsUnlockButton}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
Refactored the mobile and web dev tools screens into smaller reusable components for the password form and feature toggle list. Updated the mobile password form to work better with the keyboard and keep the input/button full width. Added GitHub Actions support for EXPO_PUBLIC_DEV_TOOLS_PASSWORD so Android builds fail early when the dev tools password is missing and pass it into the build.